### PR TITLE
Alignmentfix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
           rm -rf singularity
           singularity --version
 
-      - name: Install IVA assembler
+      - name: Install IVA assembler dependencies
         run: |
           sudo apt-get install -qq zlib1g-dev libncurses5-dev libncursesw5-dev mummer ncbi-blast+
           cd ~/bin
@@ -75,9 +75,12 @@ jobs:
           echo "/opt/bowtie2" >> $GITHUB_PATH
 
       - name: Install MiCall's Python dependencies
+        # Have to clean up alignment build files. Otherwise, they'll get reused
+        # in Singularity build with the wrong GLIBC libraries.
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-test.txt
+          rm -rf micall/alignment/build/ micall/alignment/gotoh.egg-info/
 
       - name: Test with pytest
         run: coverage run --source=micall/core,micall/g2p,micall/resistance,micall/monitor -m pytest

--- a/micall/alignment/gotoh.cpp
+++ b/micall/alignment/gotoh.cpp
@@ -245,9 +245,21 @@ int align(string* seqa, string* seqb, string* newseqa, string* newseqb,
     int M = seqa->size(); // first group of pre-aligned sequences
     int N = seqb->size(); // second group
     
-    // minimum number of rows must be 2 to prevent a buffer overflow
-    // the extra row will not be used when M=0 (empty ref)
-    int nrows = (M>0) ? M+1 : 2;
+    // if empty ref, return seqb as-is, and seqa as gaps of size(seqb)
+    // prevents a buffer overflow in the traceback matrices which assume M>0
+    if (M==0)
+    {
+        int j;
+        int alignment_score=0;
+        for (j=0 ; j < N ; j++)
+        {
+            alignment_score += (j==0) ? gip : gep ;
+            *newseqa += '-';
+            *newseqb += (*seqb)[j];;
+        }
+        
+        return alignment_score;
+    }
     
     int i, j;
 
@@ -257,8 +269,8 @@ int align(string* seqa, string* seqb, string* newseqa, string* newseqb,
     int *PP = new int[N+1];  // P(i, .)
 
     // Gotoh traceback matrices
-    int **piSS = new int*[nrows];
-    int **pjSS = new int*[nrows];
+    int **piSS = new int*[M+1];
+    int **pjSS = new int*[M+1];
 
     int u = -gip; // affine gap initiation penalty
     int v = -gep; // affine gap extension penalty
@@ -516,7 +528,7 @@ int align(string* seqa, string* seqb, string* newseqa, string* newseqb,
     reverse(newseqa);
     reverse(newseqb);
 
-    for (i = 0; i < nrows; i++)
+    for (i = 0; i < M + 1; i++)
     {
         delete []piSS[i];
         delete []pjSS[i];

--- a/micall/alignment/gotoh.cpp
+++ b/micall/alignment/gotoh.cpp
@@ -253,7 +253,8 @@ int align(string* seqa, string* seqb, string* newseqa, string* newseqb,
         int alignment_score=0;
         for (j=0 ; j < N ; j++)
         {
-            alignment_score += (j==0) ? gip : gep ;
+            //skip terminal (whole seq) gap penalties if user specifies this option
+            if (use_terminal_gap_penalty==0) alignment_score += (j==0) ? (gip+gep) : gep ;
             *newseqa += '-';
             *newseqb += (*seqb)[j];;
         }

--- a/micall/alignment/gotoh.cpp
+++ b/micall/alignment/gotoh.cpp
@@ -244,7 +244,11 @@ int align(string* seqa, string* seqb, string* newseqa, string* newseqb,
 
     int M = seqa->size(); // first group of pre-aligned sequences
     int N = seqb->size(); // second group
-
+    
+    // minimum number of rows must be 2 to prevent a buffer overflow
+    // the extra row will not be used when M=0 (empty ref)
+    int nrows = (M>0) ? M+1 : 2;
+    
     int i, j;
 
     // not all elements of D, P, and Q need to be stored - vectors are adequate
@@ -253,8 +257,8 @@ int align(string* seqa, string* seqb, string* newseqa, string* newseqb,
     int *PP = new int[N+1];  // P(i, .)
 
     // Gotoh traceback matrices
-    int **piSS = new int*[M+1];
-    int **pjSS = new int*[M+1];
+    int **piSS = new int*[nrows];
+    int **pjSS = new int*[nrows];
 
     int u = -gip; // affine gap initiation penalty
     int v = -gep; // affine gap extension penalty
@@ -512,7 +516,7 @@ int align(string* seqa, string* seqb, string* newseqa, string* newseqb,
     reverse(newseqa);
     reverse(newseqb);
 
-    for (i = 0; i < M + 1; i++)
+    for (i = 0; i < nrows; i++)
     {
         delete []piSS[i];
         delete []pjSS[i];

--- a/micall/alignment/setup.py
+++ b/micall/alignment/setup.py
@@ -5,7 +5,7 @@ gotoh = Extension('gotoh',
                     define_macros=[('__PYTHON__', None)])
 
 setup (name = 'gotoh',
-       version = '0.2',
+       version = '0.3',
        description = "Wrapper for Conan's alignment.cpp code",
        ext_modules = [gotoh],
        zip_safe = False) #avoid headache with permissions on ~/.python-eggs

--- a/micall/tests/test_align_it_gotoh.py
+++ b/micall/tests/test_align_it_gotoh.py
@@ -1,6 +1,5 @@
 import unittest
-
-from micall.alignment import gotoh
+from gotoh import align_it, align_it_aa
 
 
 class AlignItGotohTest(unittest.TestCase):
@@ -12,7 +11,7 @@ class AlignItGotohTest(unittest.TestCase):
         gep=1
         use_terminal_gap_penalty=0
 
-        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+        [result_seqa, result_seqb, result_score] = align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
 
         expected_seqa = "-"*len(seqb)
         expected_seqb = seqb
@@ -31,7 +30,7 @@ class AlignItGotohTest(unittest.TestCase):
         gep=1
         use_terminal_gap_penalty=0
 
-        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+        [result_seqa, result_seqb, result_score] = align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
 
         expected_seqa = seqa
         expected_seqb = "-"*len(seqa)
@@ -50,7 +49,7 @@ class AlignItGotohTest(unittest.TestCase):
         gep=1
         use_terminal_gap_penalty=1
 
-        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+        [result_seqa, result_seqb, result_score] = align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
 
         expected_seqa = ""
         expected_seqb = ""
@@ -69,7 +68,7 @@ class AlignItGotohTest(unittest.TestCase):
         gep=1
         use_terminal_gap_penalty=1
 
-        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+        [result_seqa, result_seqb, result_score] = align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
 
         expected_seqa = "CTCGGCTTGCTGAAGCGCGCACGGCAAGAGGCGAG"
         expected_seqb = "---------CT--AGCG----------GAGGCTAG"
@@ -88,7 +87,7 @@ class AlignItGotohTest(unittest.TestCase):
         gep=0
         use_terminal_gap_penalty=1
 
-        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+        [result_seqa, result_seqb, result_score] = align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
 
         expected_seqa = "CTCGGCTTGCTGAAGCGCGCACGGC-AAGAGGCGAG"
         expected_seqb = "CT----------A-GCG-G-A-GGCTA-G-------"
@@ -109,7 +108,7 @@ class AlignItGotohTest(unittest.TestCase):
         gep=1
         use_terminal_gap_penalty=1
 
-        [result_seqa, result_seqb, result_score] = gotoh.align_it_aa(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+        [result_seqa, result_seqb, result_score] = align_it_aa(seqa, seqb, gip, gep, use_terminal_gap_penalty)
 
         expected_seqa = "ME--PVD--P-RLEP---W--------K-----H-P-----G-SQP--KTACTNCY---C----------KKCC--F-HCQVCF-ITKALG-----ISYG--RKKRRQRRRAHQNSQTHQASLSKQ*"
         expected_seqb = "MEQAPEDQGPQR-EPHNEWTLELLEELKNEAVRHFPRIWLHGLGQHIYET-----YGDTWAGVEAIIRILQQ--LLFIH----FRI----GCRHSRI--GVT----RQRR-AR-NG----ASRS--*"
@@ -130,7 +129,7 @@ class AlignItGotohTest(unittest.TestCase):
         gep=0
         use_terminal_gap_penalty=1
 
-        [result_seqa, result_seqb, result_score] = gotoh.align_it_aa(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+        [result_seqa, result_seqb, result_score] = align_it_aa(seqa, seqb, gip, gep, use_terminal_gap_penalty)
 
         expected_seqa = "ME--PV-D--P-RLEP---W--------K-----H-P-----GS--QPK----TACTNCYC-----------KKCC------F-HCQVCFITKALGISYG-RKK--R----RQRRRAHQ-NSQTHQ-ASL-SKQ*"
         expected_seqb = "MEQAP-EDQGPQR-EPHNEWTLELLEELKNEAVRHFPRIWLHG-LGQ--HIYET-----Y-GDTWAGVEAIIR---ILQQLLFIH----F--R---I--GCR--HSRIGVTRQRR-A--RN-----GAS-RS--*"

--- a/micall/tests/test_align_it_gotoh.py
+++ b/micall/tests/test_align_it_gotoh.py
@@ -1,0 +1,141 @@
+import unittest
+
+from micall.alignment import gotoh
+
+
+class AlignItGotohTest(unittest.TestCase):
+    def test_empty_ref(self):
+        seqa = ""
+        seqb = "CTCGGCTTGCTGAAGCGCGCACGGCAAGAGGCGAG" #HIV1B-sl1
+
+        gip=4
+        gep=1
+        use_terminal_gap_penalty=0
+
+        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+
+        expected_seqa = "-"*len(seqb)
+        expected_seqb = seqb
+        expected_score = gip + gep*len(seqb)
+
+        self.assertEqual(expected_seqa, result_seqa)
+        self.assertEqual(expected_seqb, result_seqb)
+        self.assertEqual(expected_score, result_score)
+
+
+    def test_empty_seq(self):
+        seqa = "CTCGGCTTGCTGAAGCGCGCACGGCAAGAGGCGAG" #HIV1B-sl1
+        seqb = ""
+
+        gip=4
+        gep=1
+        use_terminal_gap_penalty=0
+
+        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+
+        expected_seqa = seqa
+        expected_seqb = "-"*len(seqa)
+        expected_score = gip + gep*len(seqa)
+
+        self.assertEqual(expected_seqa, result_seqa)
+        self.assertEqual(expected_seqb, result_seqb)
+        self.assertEqual(expected_score, result_score)
+
+
+    def test_empty_all(self):
+        seqa = ""
+        seqb = ""
+
+        gip=4
+        gep=1
+        use_terminal_gap_penalty=1
+
+        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+
+        expected_seqa = ""
+        expected_seqb = ""
+        expected_score = 0
+
+        self.assertEqual(expected_seqa, result_seqa)
+        self.assertEqual(expected_seqb, result_seqb)
+        self.assertEqual(expected_score, result_score)
+
+
+    def test_align_it(self):
+        seqa = "CTCGGCTTGCTGAAGCGCGCACGGCAAGAGGCGAG" # HIV1B-sl1
+        seqb = "CTAGCGGAGGCTAG" # HIV1B-sl3
+
+        gip=4
+        gep=1
+        use_terminal_gap_penalty=1
+
+        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+
+        expected_seqa = "CTCGGCTTGCTGAAGCGCGCACGGCAAGAGGCGAG"
+        expected_seqb = "---------CT--AGCG----------GAGGCTAG"
+        expected_score = 41
+
+        self.assertEqual(expected_seqa, result_seqa)
+        self.assertEqual(expected_seqb, result_seqb)
+        self.assertEqual(expected_score, result_score)
+
+
+    def test_align_it_zero_penalty(self):
+        seqa = "CTCGGCTTGCTGAAGCGCGCACGGCAAGAGGCGAG" # HIV1B-sl1
+        seqb = "CTAGCGGAGGCTAG" # HIV1B-sl3
+
+        gip=0
+        gep=0
+        use_terminal_gap_penalty=1
+
+        [result_seqa, result_seqb, result_score] = gotoh.align_it(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+
+        expected_seqa = "CTCGGCTTGCTGAAGCGCGCACGGC-AAGAGGCGAG"
+        expected_seqb = "CT----------A-GCG-G-A-GGCTA-G-------"
+        expected_score = 65
+
+        self.assertEqual(expected_seqa, result_seqa)
+        self.assertEqual(expected_seqb, result_seqb)
+        self.assertEqual(expected_score, result_score)
+
+
+    def test_align_it_aa(self):
+        # HIV1B-tat
+        seqa = "MEPVDPRLEPWKHPGSQPKTACTNCYCKKCCFHCQVCFITKALGISYGRKKRRQRRRAHQNSQTHQASLSKQ*"
+        # HIV1B-vpr
+        seqb = "MEQAPEDQGPQREPHNEWTLELLEELKNEAVRHFPRIWLHGLGQHIYETYGDTWAGVEAIIRILQQLLFIHFRIGCRHSRIGVTRQRRARNGASRS*"
+
+        gip=4
+        gep=1
+        use_terminal_gap_penalty=1
+
+        [result_seqa, result_seqb, result_score] = gotoh.align_it_aa(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+
+        expected_seqa = "ME--PVD--P-RLEP---W--------K-----H-P-----G-SQP--KTACTNCY---C----------KKCC--F-HCQVCF-ITKALG-----ISYG--RKKRRQRRRAHQNSQTHQASLSKQ*"
+        expected_seqb = "MEQAPEDQGPQR-EPHNEWTLELLEELKNEAVRHFPRIWLHGLGQHIYET-----YGDTWAGVEAIIRILQQ--LLFIH----FRI----GCRHSRI--GVT----RQRR-AR-NG----ASRS--*"
+        expected_score = 49
+
+        self.assertEqual(expected_seqa, result_seqa)
+        self.assertEqual(expected_seqb, result_seqb)
+        self.assertEqual(expected_score, result_score)
+
+
+    def test_align_it_aa_zero_penalty(self):
+        # HIV1B-tat
+        seqa = "MEPVDPRLEPWKHPGSQPKTACTNCYCKKCCFHCQVCFITKALGISYGRKKRRQRRRAHQNSQTHQASLSKQ*"
+        # HIV1B-vpr
+        seqb = "MEQAPEDQGPQREPHNEWTLELLEELKNEAVRHFPRIWLHGLGQHIYETYGDTWAGVEAIIRILQQLLFIHFRIGCRHSRIGVTRQRRARNGASRS*"
+
+        gip=0
+        gep=0
+        use_terminal_gap_penalty=1
+
+        [result_seqa, result_seqb, result_score] = gotoh.align_it_aa(seqa, seqb, gip, gep, use_terminal_gap_penalty)
+
+        expected_seqa = "ME--PV-D--P-RLEP---W--------K-----H-P-----GS--QPK----TACTNCYC-----------KKCC------F-HCQVCFITKALGISYG-RKK--R----RQRRRAHQ-NSQTHQ-ASL-SKQ*"
+        expected_seqb = "MEQAP-EDQGPQR-EPHNEWTLELLEELKNEAVRHFPRIWLHG-LGQ--HIYET-----Y-GDTWAGVEAIIR---ILQQLLFIH----F--R---I--GCR--HSRIGVTRQRR-A--RN-----GAS-RS--*"
+        expected_score = 260
+
+        self.assertEqual(expected_seqa, result_seqa)
+        self.assertEqual(expected_seqb, result_seqb)
+        self.assertEqual(expected_score, result_score)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 pytz==2021.3
 git+https://github.com/cfe-lab/iva.git@v1.1.1
 biopython==1.79
-git+https://github.com/cfe-lab/MiCall.git@v7.7.0#egg=gotoh&subdirectory=micall/alignment
+micall/alignment
 git+https://github.com/cfe-lab/pyvdrm.git@v0.3.1
 numpy==1.21.4
 scipy==1.7.3


### PR DESCRIPTION
Fixes a buffer overflow in the Gotoh algorithm that happens when the reference sequence string is empty. Gotoh's algorithm initializes with a minimum of two rows. So in the case of an empty ref string, we will return a sequence of gaps (and calculate the affine gap penalty as expected). The issue does not extend to the case where we have an empty sequence b.