### PR TITLE
Translated insertions

### DIFF
--- a/micall/core/aln2counts.py
+++ b/micall/core/aln2counts.py
@@ -126,23 +126,14 @@ def trim_contig_name(contig_name):
 def get_insertion_info(right, report_aminos, report_nucleotides):
     insert_behind = None
     insertion_coverage = 0
-    for i, report_amino in enumerate(report_aminos):
-        seed_amino = report_amino.seed_amino
-        if seed_amino.consensus_nuc_index == right:
-            insert_behind = (report_amino.position - 1) * 3
-            coverage_left = report_aminos[i - 1].seed_amino.nucleotides[2].get_coverage() if i >= 0 else 0
-            coverage_right = report_amino.seed_amino.nucleotides[0].get_coverage()
+    for i, report_nuc in enumerate(report_nucleotides):
+        seed_nuc = report_nuc.seed_nucleotide
+        if seed_nuc.consensus_index == right:
+            insert_behind = report_nuc.position - 1
+            coverage_left = report_nucleotides[i - 1].seed_nucleotide.get_coverage() if i >= 0 else 0
+            coverage_right = report_nuc.seed_nucleotide.get_coverage()
             insertion_coverage = max(coverage_left, coverage_right)
             break
-    if len(report_aminos) == 0:
-        for i, report_nuc in enumerate(report_nucleotides):
-            seed_nuc = report_nuc.seed_nucleotide
-            if seed_nuc.consensus_index == right:
-                insert_behind = report_nuc.position - 1
-                coverage_left = report_nucleotides[i - 1].seed_nucleotide.get_coverage() if i >= 0 else 0
-                coverage_right = report_nuc.seed_nucleotide.get_coverage()
-                insertion_coverage = max(coverage_left, coverage_right)
-                break
     return insert_behind, insertion_coverage
 
 

--- a/micall/core/aln2counts.py
+++ b/micall/core/aln2counts.py
@@ -1662,7 +1662,7 @@ class InsertionWriter(object):
                 if current_insert_behind is not None:
                     for position in insertions:
                         insertions[position].count_nucleotides('-', count=current_insert_coverage)
-                    if self.ref_insertions[region][current_insert_behind - 1] is None:
+                    if len(self.ref_insertions[region][current_insert_behind - 1]) == 0:
                         self.ref_insertions[region][current_insert_behind - 1] = insertions
                     else:
                         present_insertions = self.ref_insertions[region][current_insert_behind - 1]

--- a/micall/core/aln2counts.py
+++ b/micall/core/aln2counts.py
@@ -220,7 +220,9 @@ def insert_insertions(insertions, consensus_nucs):
             coverage_insertion = insertions[position][i].get_coverage()
             coverage_no_insertion = coverage_nuc - coverage_insertion
             if coverage_no_insertion > 0:
-                insertions[position][i].counts['-'] = coverage_no_insertion
+                # the non-insertion coverage is already set in aggregate_insertions and count_conseq_insertions for
+                # each individual contig, but here we increase it if necessary for the whole genome consensus counts.
+                insertions[position][i].counts['-'] += coverage_no_insertion
             consensus_nucs[insertion_position] = insertions[position][i]
 
 
@@ -1661,12 +1663,13 @@ class InsertionWriter(object):
                     get_insertion_info(insertion_position, report_aminos, report_nucleotides)
                 if current_insert_behind is not None:
                     for position in insertions:
-                        insertions[position].count_nucleotides('-', count=current_insert_coverage)
+                        insertions[position].counts['-'] = current_insert_coverage
                     if len(self.ref_insertions[region][current_insert_behind - 1]) == 0:
                         self.ref_insertions[region][current_insert_behind - 1] = insertions
                     else:
                         present_insertions = self.ref_insertions[region][current_insert_behind - 1]
-                        new_insertions = insertions
+                        new_insertions = defaultdict(SeedNucleotide)
+                        new_insertions.update(insertions)
                         length_conseq_insertions = len(insertions)
                         # shift present insertions by the length of the new insertions
                         for position, insertion in present_insertions.items():

--- a/micall/core/aln2counts.py
+++ b/micall/core/aln2counts.py
@@ -1631,17 +1631,16 @@ class InsertionWriter(object):
                         current_nuc_counts[insert_nuc_seq] += count
 
             for left, counts in insert_nuc_counts.items():
-                pos = insert_behind.get(left)
-                if pos is None:
+                insert_pos = insert_behind.get(left)
+                if insert_pos is None:
                     # this can happen if the insertion is at the start of an alignment,
                     # because we only look at the consensus on the left edge of the insert
                     continue
-                ref_pos = pos - 1
+                ref_pos = insert_pos - 1
                 self.ref_insertions[region][ref_pos] =\
                     aggregate_insertions(insert_nuc_counts[left],
                                          consensus_pos=left-1,
                                          coverage_nuc=insertion_coverage[left])
-                insert_pos = insert_behind.get(left)
                 count = sum(counts.values())
                 # Only care about insertions in the middle of the sequence,
                 # so ignore any that come before or after the reference.

--- a/micall/tests/test_aln2counts.py
+++ b/micall/tests/test_aln2counts.py
@@ -1319,14 +1319,14 @@ R1-seed,R1,15,7,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,5
         self.assertEqual(expected_text, self.report_file.getvalue())
 
     def testInsertionBetweenSeedAndCoordinateAminoReport(self):
-        """ Coordinate sequence is KFQTPREH, and this aligned read is HERKFQTGPREHQFK.
+        """ Coordinate sequence is KFQTPREH, and this aligned read is HERKFQTGPREH.
 
         The G must be an insertion in the seed reference with respect to the
         coordinate reference.
         """
         # refname,qcut,rank,count,offset,seq
         aligned_reads = prepare_reads("""\
-R3-seed,15,0,9,0,CATGAGCGAAAATTTCAGACTGGGCCCCGAGAGCATCAGTTTAAA
+R3-seed,15,0,9,0,CATGAGCGAAAATTTCAGACTGGGCCCCGAGAGCAT
 """)
         self.report.landmarks = yaml.safe_load("""\
 - seed_pattern: R3-.*
@@ -1366,14 +1366,14 @@ R3-seed,0.100,R3,12,12,21,GGG
                          self.report.insert_writer.insert_file.getvalue())
 
     def testInsertionBetweenSeedAndCoordinateNucleotideReport(self):
-        """ Coordinate sequence is KFQTPREH, and this aligned read is HERKFQTGPREHQFK.
+        """ Coordinate sequence is KFQTPREH, and this aligned read is HERKFQTGPREH.
 
         The G must be an insertion in the seed reference with respect to the
         coordinate reference.
         """
         # refname,qcut,rank,count,offset,seq
         aligned_reads = prepare_reads("""\
-R3-seed,15,0,9,0,CATGAGCGAAAATTTCAGACTGGGCCCCGAGAGCATCAGTTTAAA
+R3-seed,15,0,9,0,CATGAGCGAAAATTTCAGACTGGGCCCCGAGAGCAT
 """)
         self.report.landmarks = yaml.safe_load("""\
 - seed_pattern: R3-.*
@@ -1421,8 +1421,8 @@ R3-seed,R3,15,36,24,24,0,0,0,9,0,0,0,0,0,9
     def testInsertionsSortedByCount(self):
         # refname,qcut,rank,count,offset,seq
         aligned_reads = prepare_reads("""\
-R3-seed,15,0,9,0,CATGAGCGAAAATTTCAGACTGGGCCCCGAGAGCATCAGTTTAAA
-R3-seed,15,0,8,0,CATGAGCGAAAATTTCAGACTAAACCCCGAGAGCATCAGTTTAAA
+R3-seed,15,0,9,0,CATGAGCGAAAATTTCAGACTGGGCCCCGAGAGCAT
+R3-seed,15,0,8,0,CATGAGCGAAAATTTCAGACTAAACCCCGAGAGCAT
 """)
         self.report.landmarks = yaml.safe_load("""\
 - seed_pattern: R3-.*

--- a/micall/tests/test_aln2counts.py
+++ b/micall/tests/test_aln2counts.py
@@ -2319,7 +2319,7 @@ seed,mixture_cutoff,region,ref_region_pos,ref_genome_pos,query_pos,insertion
 R1-seed,MAX,R1,6,6,6,GAC
 R1-seed,0.100,R1,6,6,6,GAC
 """
-        expected_counts = {('R1-seed', 'R1'): {2: 1}}
+        expected_counts = {('R1-seed', 'R1'): {6: 1}}
 
         report_aminos = {'R1': [ReportAmino(SeedAmino(0), 1),
                                 ReportAmino(SeedAmino(3), 2),

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1229,6 +1229,68 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,12,11,800,0,0,10,0,0,0,0,0,0,10"""
 
 
 # noinspection DuplicatedCode
+def test_nuc_small_majority_insertion(default_sequence_report):
+    """ Check that a small insertion relative to the reference is correctly inserted into the nuc.csv file
+    for translated untranslated regions"""
+    aligned_reads = prepare_reads("""\
+HIV1-B-FR-K03455-seed,15,0,10,1,\
+ATGGGTGCGAGAGCGTCAGTATTAAGCGGGGGAGAATTAGATCGATGGGAAAAATTTTTTTTTATTCGGTTAAGGCCAGGGGGAAAGAAAAAATATAAATTAAAACATAT
+""")
+    # this is the ref genome from pos 789 to 889 (0 based), with an insertion here:
+    #                                                 ^^^^^^^^^
+
+    expected_text = """\
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,53,52,841,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,54,53,842,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,55,54,843,10,0,0,0,0,0,10,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,65,55,844,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,66,56,845,0,0,0,10,0,0,0,0,0,10"""
+
+    nuc_file = StringIO()
+    default_sequence_report.read(aligned_reads)
+    default_sequence_report.write_nuc_header(nuc_file)
+    default_sequence_report.write_insertions(default_sequence_report.insert_writer)
+    default_sequence_report.write_nuc_counts()  # calculates ins counts
+    report = nuc_file.getvalue()
+    report_lines = report.splitlines()
+    key_lines = report_lines[52:57]
+    key_report = '\n'.join(key_lines)
+    assert key_report == expected_text
+
+
+# noinspection DuplicatedCode
+@pytest.mark.skip(reason="currently failing")
+def test_nuc_large_majority_insertion(default_sequence_report):
+    """ Check that a large (>30) insertion relative to the reference is correctly inserted into the nuc.csv file
+    for translated untranslated regions"""
+    aligned_reads = prepare_reads("""\
+HIV1-B-FR-K03455-seed,15,0,10,1,\
+ATGGGTGCGAGAGCGTCAGTATTAAGCGGGGGAGAATTAGATCGATGGGAAAAATTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTATTCGGTTAAGG\
+CCAGGGGGAAAGAAAAAATATAAATTAAAACATAT
+""")
+    # this is the ref genome from pos 789 to 889 (0 based), with an insertion here:
+    #                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    expected_text = """\
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,53,52,841,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,54,53,842,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,55,54,843,10,0,0,0,0,0,10,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,89,55,844,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
+
+    nuc_file = StringIO()
+    default_sequence_report.read(aligned_reads)
+    default_sequence_report.write_nuc_header(nuc_file)
+    default_sequence_report.write_insertions(default_sequence_report.insert_writer)
+    default_sequence_report.write_nuc_counts()  # calculates ins counts
+    report = nuc_file.getvalue()
+    report_lines = report.splitlines()
+    key_lines = report_lines[52:57]
+    key_report = '\n'.join(key_lines)
+    assert key_report == expected_text
+
+
+# noinspection DuplicatedCode
 def test_whole_genome_consensus_different_minority_insertions(default_sequence_report):
     """ Check that different insertions relative to the consensus are correctly inserted
     into the whole genome consensus"""

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1290,7 +1290,6 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
 
 
 # noinspection DuplicatedCode
-@pytest.mark.skip(reason="currently failing")
 def test_nuc_large_majority_insertion_frameshift(default_sequence_report):
     """ Check that a large (>30) insertion relative to the reference is correctly inserted into the nuc.csv file
     for translated regions, even if it is out of frame"""

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1259,7 +1259,6 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,66,56,845,0,0,0,10,0,0,0,0,0,10"""
 
 
 # noinspection DuplicatedCode
-@pytest.mark.skip(reason="currently failing")
 def test_nuc_large_majority_insertion(default_sequence_report):
     """ Check that a large (>30) insertion relative to the reference is correctly inserted into the nuc.csv file
     for translated untranslated regions"""

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1261,7 +1261,7 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,66,56,845,0,0,0,10,0,0,0,0,0,10"""
 # noinspection DuplicatedCode
 def test_nuc_large_majority_insertion(default_sequence_report):
     """ Check that a large (>30) insertion relative to the reference is correctly inserted into the nuc.csv file
-    for translated untranslated regions"""
+    for translated regions"""
     aligned_reads = prepare_reads("""\
 HIV1-B-FR-K03455-seed,15,0,10,1,\
 ATGGGTGCGAGAGCGTCAGTATTAAGCGGGGGAGAATTAGATCGATGGGAAAAATTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTATTCGGTTAAGG\
@@ -1293,7 +1293,7 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
 @pytest.mark.skip(reason="currently failing")
 def test_nuc_large_majority_insertion_frameshift(default_sequence_report):
     """ Check that a large (>30) insertion relative to the reference is correctly inserted into the nuc.csv file
-    for translated untranslated regions"""
+    for translated regions, even if it is out of frame"""
     aligned_reads = prepare_reads("""\
 HIV1-B-FR-K03455-seed,15,0,10,1,\
 ATGGGTGCGAGAGCGTCAGTATTAAGCGGGGGAGAATTAGATCGATGGGAAAATTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTAATTCGGTTAAGG\
@@ -1303,9 +1303,11 @@ CCAGGGGGAAAGAAAAAATATAAATTAAAACATAT
     #                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     expected_text = """\
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,51,50,839,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,52,51,840,10,0,0,0,0,0,0,0,0,10
 HIV1-B-FR-K03455-seed,HIV1B-gag,15,53,52,841,10,0,0,0,0,0,0,0,0,10
-HIV1-B-FR-K03455-seed,HIV1B-gag,15,54,53,842,10,0,0,0,0,0,0,0,0,10
-HIV1-B-FR-K03455-seed,HIV1B-gag,15,88,54,843,10,0,0,0,0,0,10,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,54,53,842,10,0,0,0,0,0,10,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,88,54,843,10,0,0,0,0,0,0,0,0,10
 HIV1-B-FR-K03455-seed,HIV1B-gag,15,89,55,844,10,0,0,0,0,0,0,0,0,10
 HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
 
@@ -1316,7 +1318,7 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
     default_sequence_report.write_nuc_counts()  # calculates ins counts
     report = nuc_file.getvalue()
     report_lines = report.splitlines()
-    key_lines = report_lines[52:57]
+    key_lines = report_lines[50:57]
     key_report = '\n'.join(key_lines)
     assert key_report == expected_text
 

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1398,6 +1398,49 @@ CCAGGGGGAAAGAAAAAATATAAATTAAAACATAT
 
 
 # noinspection DuplicatedCode
+def test_insertion_end_of_region(default_sequence_report):
+    """ Check that an insertion relative to the consensus is not inserted into conseq_regions
+    if it is located at the very end of the region"""
+    aligned_reads = prepare_reads("""\
+1-HIV1-B-FR-K03455-seed,15,0,10,0,\
+CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAAAGATAGGG
+""")
+    # this is the ref genome from pos 2200 to 2300 (0 based), with an insertion here:
+    #                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    conseq_ins_csv = StringIO("""\
+qname,fwd_rev,refname,pos,insert,qual
+Example_read_1,F,1-HIV1-B-FR-K03455-seed,92,AAC,AAA
+Example_read_2,F,1-HIV1-B-FR-K03455-seed,92,AAC,AAA
+Example_read_3,F,1-HIV1-B-FR-K03455-seed,92,AAC,AAA
+""")
+
+    expected_regions = """\
+seed,region,q-cutoff,consensus-percent-cutoff,offset,sequence
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,MAX,1411,\
+CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAA
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,0.100,1411,\
+CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAA"""
+
+    regions_file = StringIO()
+    default_sequence_report.read_insertions(conseq_ins_csv)
+    default_sequence_report.write_consensus_stitched_header(StringIO())
+    default_sequence_report.write_consensus_regions_header(regions_file)
+    default_sequence_report.read(aligned_reads)
+    default_sequence_report.write_nuc_header(StringIO())
+    default_sequence_report.write_insertions(default_sequence_report.insert_writer)
+    default_sequence_report.write_nuc_counts()  # calculates ins counts
+    default_sequence_report.combine_reports()
+    default_sequence_report.write_whole_genome_consensus_from_nuc()
+    default_sequence_report.write_consensus_regions()
+    report = regions_file.getvalue()
+    report_lines = report.splitlines()
+    key_lines = report_lines[0:3]
+    key_report = '\n'.join(key_lines)
+    assert key_report == expected_regions
+
+
+# noinspection DuplicatedCode
 def test_whole_genome_consensus_different_minority_insertions(default_sequence_report):
     """ Check that different insertions relative to the consensus are correctly inserted
     into the whole genome consensus"""

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1290,6 +1290,38 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
 
 
 # noinspection DuplicatedCode
+@pytest.mark.skip(reason="currently failing")
+def test_nuc_large_majority_insertion_frameshift(default_sequence_report):
+    """ Check that a large (>30) insertion relative to the reference is correctly inserted into the nuc.csv file
+    for translated untranslated regions"""
+    aligned_reads = prepare_reads("""\
+HIV1-B-FR-K03455-seed,15,0,10,1,\
+ATGGGTGCGAGAGCGTCAGTATTAAGCGGGGGAGAATTAGATCGATGGGAAAATTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTAATTCGGTTAAGG\
+CCAGGGGGAAAGAAAAAATATAAATTAAAACATAT
+""")
+    # this is the ref genome from pos 789 to 889 (0 based), with an insertion here:
+    #                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    expected_text = """\
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,53,52,841,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,54,53,842,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,88,54,843,10,0,0,0,0,0,10,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,89,55,844,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
+
+    nuc_file = StringIO()
+    default_sequence_report.read(aligned_reads)
+    default_sequence_report.write_nuc_header(nuc_file)
+    default_sequence_report.write_insertions(default_sequence_report.insert_writer)
+    default_sequence_report.write_nuc_counts()  # calculates ins counts
+    report = nuc_file.getvalue()
+    report_lines = report.splitlines()
+    key_lines = report_lines[52:57]
+    key_report = '\n'.join(key_lines)
+    assert key_report == expected_text
+
+
+# noinspection DuplicatedCode
 def test_whole_genome_consensus_different_minority_insertions(default_sequence_report):
     """ Check that different insertions relative to the consensus are correctly inserted
     into the whole genome consensus"""

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1323,6 +1323,40 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
 
 
 # noinspection DuplicatedCode
+@pytest.mark.skip(reason="Another insertion that fails to be recorded")
+def test_nuc_large_insertion_not_multiple_of_three(default_sequence_report):
+    """ Check that a large (>30) insertion relative to the reference is correctly inserted into the nuc.csv file
+    for translated regions, even if it is out of frame"""
+    aligned_reads = prepare_reads("""\
+HIV1-B-FR-K03455-seed,15,0,10,1,\
+ATGGGTGCGAGAGCGTCAGTATTAAGCGGGGGAGAATTAGATCGATGGGAAAATTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTAATTCGGTTAAGG\
+CCAGGGGGAAAGAAAAAATATAAATTAAAACATAT
+""")
+    # this is the ref genome from pos 789 to 889 (0 based), with an insertion here:
+    #                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    expected_text = """\
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,51,50,839,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,52,51,840,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,53,52,841,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,54,53,842,10,0,0,0,0,0,10,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,89,54,843,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,55,844,10,0,0,0,0,0,0,0,0,10
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,91,56,845,0,0,0,10,0,0,0,0,0,10"""
+
+    nuc_file = StringIO()
+    default_sequence_report.read(aligned_reads)
+    default_sequence_report.write_nuc_header(nuc_file)
+    default_sequence_report.write_insertions(default_sequence_report.insert_writer)
+    default_sequence_report.write_nuc_counts()  # calculates ins counts
+    report = nuc_file.getvalue()
+    report_lines = report.splitlines()
+    key_lines = report_lines[50:57]
+    key_report = '\n'.join(key_lines)
+    assert key_report == expected_text
+
+
+# noinspection DuplicatedCode
 def test_whole_genome_consensus_different_minority_insertions(default_sequence_report):
     """ Check that different insertions relative to the consensus are correctly inserted
     into the whole genome consensus"""

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1405,8 +1405,7 @@ def test_insertion_end_of_region(default_sequence_report):
 1-HIV1-B-FR-K03455-seed,15,0,10,0,\
 CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAAAGATAGGG
 """)
-    # this is the ref genome from pos 2200 to 2300 (0 based), with an insertion here:
-    #                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    # this is the ref genome from pos 2200 to 2300 (0 based)
 
     conseq_ins_csv = StringIO("""\
 qname,fwd_rev,refname,pos,insert,qual
@@ -1421,6 +1420,46 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,MAX,1411,\
 CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAA
 HIV1-B-FR-K03455-seed,HIV1B-gag,15,0.100,1411,\
 CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAA"""
+
+    regions_file = StringIO()
+    default_sequence_report.read_insertions(conseq_ins_csv)
+    default_sequence_report.write_consensus_stitched_header(StringIO())
+    default_sequence_report.write_consensus_regions_header(regions_file)
+    default_sequence_report.read(aligned_reads)
+    default_sequence_report.write_nuc_header(StringIO())
+    default_sequence_report.write_insertions(default_sequence_report.insert_writer)
+    default_sequence_report.write_nuc_counts()  # calculates ins counts
+    default_sequence_report.combine_reports()
+    default_sequence_report.write_whole_genome_consensus_from_nuc()
+    default_sequence_report.write_consensus_regions()
+    report = regions_file.getvalue()
+    report_lines = report.splitlines()
+    key_lines = report_lines[0:3]
+    key_report = '\n'.join(key_lines)
+    assert key_report == expected_regions
+
+
+# noinspection DuplicatedCode
+def test_insertion_10percent(default_sequence_report):
+    """ Check that an insertion relative to the consensus is inserted into conseq_regions
+    if its coverage is exactly 10%"""
+    aligned_reads = prepare_reads("""\
+1-HIV1-B-FR-K03455-seed,15,0,9,0,\
+CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAAAGATAGGG
+""")
+    # this is the ref genome from pos 2200 to 2300 (0 based)
+
+    conseq_ins_csv = StringIO("""\
+qname,fwd_rev,refname,pos,insert,qual
+Example_read_1,F,1-HIV1-B-FR-K03455-seed,91,AAC,AAA
+""")
+
+    expected_regions = """\
+seed,region,q-cutoff,consensus-percent-cutoff,offset,sequence
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,MAX,1411,\
+CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAA
+HIV1-B-FR-K03455-seed,HIV1B-gag,15,0.100,1411,\
+CTCCCCCTCAGAAGCAGGAGCCGATAGACAAGGAACTGTATCCTTTAACTTCCCTCAGGTCACTCTTTGGCAACGACCCCTCGTCACAATAaacA"""
 
     regions_file = StringIO()
     default_sequence_report.read_insertions(conseq_ins_csv)
@@ -1753,7 +1792,7 @@ def test_consensus_insertion_translated_differences():
     region_insertions = {1: {1: insertion3}, 7: {1: insertion3}, 12: {1: insertion4}}
     region_start = 20
     prev_region_end = 29
-    consumed_positions = set(i for i in range(0,28))
+    consumed_positions = set(i for i in range(0, 28))
     is_amino = True
 
     combine_region_insertions(insertions_dict,
@@ -1780,7 +1819,7 @@ def test_consensus_insertion_untranslated_differences():
     region_insertions = {1: {1: insertion3}, 7: {1: insertion3}, 12: {1: insertion4}}
     region_start = 20
     prev_region_end = 29
-    consumed_positions = set(i for i in range(0,28))
+    consumed_positions = set(i for i in range(0, 28))
     is_amino = False
 
     combine_region_insertions(insertions_dict,

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1357,7 +1357,7 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,91,56,845,0,0,0,10,0,0,0,0,0,10"""
 
 # noinspection DuplicatedCode
 def test_majority_and_minority_insertion(default_sequence_report):
-    """ Check that an insertion relative to the reference is correctly inserted into the insertions.csv file
+    """ Check that an insertion relative to the reference is correctly inserted into conseq_regions
     for translated regions, even if there are also insertions relative to the consensus at that position"""
     aligned_reads = prepare_reads("""\
 1-HIV1-B-FR-K03455-seed,15,0,10,1,\

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -1323,7 +1323,6 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,90,56,845,0,0,0,10,0,0,0,0,0,10"""
 
 
 # noinspection DuplicatedCode
-@pytest.mark.skip(reason="Another insertion that fails to be recorded")
 def test_nuc_large_insertion_not_multiple_of_three(default_sequence_report):
     """ Check that a large (>30) insertion relative to the reference is correctly inserted into the nuc.csv file
     for translated regions, even if it is out of frame"""

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -539,7 +539,7 @@ class ConsensusAligner:
                     has_skipped_nucleotide = True
         for amino_alignment in self.amino_alignments:
             if amino_alignment.action == CigarActions.DELETE:
-                self.parse_deletion(amino_alignment,
+                self.count_deletion(amino_alignment,
                                     amino_ref,
                                     report_aminos,
                                     report_nucleotides,
@@ -547,10 +547,10 @@ class ConsensusAligner:
                                     repeat_position,
                                     skip_position)
             elif amino_alignment.action == CigarActions.INSERT:
-                self.parse_insertion(amino_alignment, start_pos, end_pos)
+                self.count_insertion(amino_alignment, start_pos, end_pos)
             else:
                 assert amino_alignment.action == CigarActions.MATCH
-                self.parse_match(amino_alignment,
+                self.count_match(amino_alignment,
                                  amino_ref,
                                  report_aminos,
                                  report_nucleotides,
@@ -594,7 +594,7 @@ class ConsensusAligner:
             report_nuc = report_nucleotides[report_nuc_index]
             report_nuc.seed_nucleotide.add(seed_nuc)
 
-    def parse_deletion(self,
+    def count_deletion(self,
                        amino_alignment,
                        amino_ref,
                        report_aminos,
@@ -642,7 +642,7 @@ class ConsensusAligner:
             if coord_index == del_end_amino_index:
                 break
 
-    def parse_insertion(self, amino_alignment, start_pos, end_pos):
+    def count_insertion(self, amino_alignment, start_pos, end_pos):
         ref_nuc_index = amino_alignment.ref_start
         consensus_nuc_index = amino_alignment.query_start + self.consensus_offset - 1
         section_size = (amino_alignment.query_end - amino_alignment.query_start) // 3
@@ -651,7 +651,7 @@ class ConsensusAligner:
                 self.inserts.add(consensus_nuc_index)
             consensus_nuc_index += 3
 
-    def parse_match(self,
+    def count_match(self,
                     amino_alignment,
                     amino_ref,
                     report_aminos,

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -539,138 +539,25 @@ class ConsensusAligner:
                     has_skipped_nucleotide = True
         for amino_alignment in self.amino_alignments:
             if amino_alignment.action == CigarActions.DELETE:
-                coverage = self.get_deletion_coverage(
-                    amino_alignment.query_start)
-                seed_amino = SeedAmino(None)
-                seed_amino.count_aminos('---', coverage)
-
-                # Start index within region
-                del_start_nuc_index = amino_alignment.ref_start - start_pos + 1
-                del_end_nuc_index = amino_alignment.ref_end - start_pos
-                # Calculate amino index. amino_alignment is already trimmed to
-                # be between start_pos and end_pos, but HIV's vpr has an extra
-                # base that can roll over to an extra amino acid. Trim to length
-                # of amino reference.
-                del_start_amino_index = min(del_start_nuc_index // 3,
-                                            len(amino_ref)-1)
-                del_end_amino_index = min(del_end_nuc_index // 3,
-                                          len(amino_ref)-1)
-                for coord_index in count(del_start_amino_index):
-                    if coord_index == del_start_amino_index:
-                        start_codon_nuc = del_start_nuc_index % 3
-                        trimmed_seed_amino = SeedAmino(None)
-                        trimmed_seed_amino.add(seed_amino, start_codon_nuc)
-                        trimmed_seed_amino.consensus_nuc_index = (
-                                amino_alignment.query_start -
-                                start_codon_nuc)
-                    elif coord_index == del_end_amino_index:
-                        end_codon_nuc = del_end_nuc_index % 3
-                        trimmed_seed_amino = SeedAmino(None)
-                        trimmed_seed_amino.add(seed_amino, 0, end_codon_nuc)
-                    else:
-                        trimmed_seed_amino = seed_amino
-                    self.update_report_amino(coord_index,
-                                             report_aminos,
-                                             report_nucleotides,
-                                             trimmed_seed_amino,
-                                             start_pos,
-                                             repeat_position)
-                    if coord_index == del_end_amino_index:
-                        break
-
+                self.parse_deletion(amino_alignment,
+                                    amino_ref,
+                                    report_aminos,
+                                    report_nucleotides,
+                                    start_pos,
+                                    repeat_position,
+                                    skip_position)
             elif amino_alignment.action == CigarActions.INSERT:
-                ref_nuc_index = amino_alignment.ref_start
-                consensus_nuc_index = amino_alignment.query_start + self.consensus_offset - 1
-                section_size = (amino_alignment.query_end - amino_alignment.query_start) // 3
-                for _ in range(section_size):
-                    if start_pos - 1 <= ref_nuc_index < end_pos:
-                        self.inserts.add(consensus_nuc_index)
-                    consensus_nuc_index += 3
-
+                self.parse_insertion(amino_alignment, start_pos, end_pos)
             else:
                 assert amino_alignment.action == CigarActions.MATCH
-                region_seed_aminos = self.reading_frames[amino_alignment.reading_frame]
-                coord2conseq = amino_alignment.map_amino_sequences()
-
-                coordinate_inserts = {seed_amino.consensus_nuc_index
-                                      for seed_amino in region_seed_aminos}
-                prev_conseq_index = None
-                prev_consensus_nuc_index = None
-                max_conseq_index = max(coord2conseq.values())
-                for coord_index in range(len(amino_ref)):
-                    conseq_index = coord2conseq.get(coord_index)
-                    if conseq_index is None:
-                        seed_amino = SeedAmino(None)
-                        if (prev_conseq_index is not None and
-                                prev_conseq_index < max_conseq_index):
-                            prev_seed_amino = region_seed_aminos[prev_conseq_index]
-                            prev_count = sum(prev_seed_amino.counts.values())
-                            prev_count += prev_seed_amino.deletions
-                            next_seed_amino = region_seed_aminos[prev_conseq_index+1]
-                            next_count = sum(next_seed_amino.counts.values())
-                            next_count += next_seed_amino.deletions
-                            min_count = min(prev_count, next_count)
-                            seed_amino.deletions = min_count
-                            for nuc in seed_amino.nucleotides:
-                                nuc.count_nucleotides('-', min_count)
-                    else:
-                        seed_amino = region_seed_aminos[conseq_index]
-                        consensus_nuc_index = seed_amino.consensus_nuc_index
-                        if consensus_nuc_index < amino_alignment.query_start:
-                            start_codon_nuc = max(0,
-                                                  amino_alignment.query_start -
-                                                  consensus_nuc_index)
-                            end_codon_nuc = 2
-                            seed_amino2 = SeedAmino(None)
-                            seed_amino2.add(seed_amino,
-                                            start_codon_nuc,
-                                            end_codon_nuc)
-                            seed_amino = seed_amino2
-                        if amino_alignment.query_end < consensus_nuc_index+3:
-                            start_codon_nuc = 0
-                            end_codon_nuc = (amino_alignment.query_end -
-                                             consensus_nuc_index - 1)
-                            seed_amino2 = SeedAmino(None)
-                            seed_amino2.add(seed_amino,
-                                            start_codon_nuc,
-                                            end_codon_nuc)
-                            seed_amino = seed_amino2
-                        if prev_conseq_index is None:
-                            coordinate_inserts = {i
-                                                  for i in coordinate_inserts
-                                                  if i >= consensus_nuc_index}
-                        prev_conseq_index = conseq_index
-
-                    if seed_amino.consensus_nuc_index is not None:
-                        coordinate_inserts.remove(seed_amino.consensus_nuc_index)
-                        prev_consensus_nuc_index = seed_amino.consensus_nuc_index
-                    if skip_position is not None and coord_index == (skip_position-start_pos)//3 and \
-                            amino_alignment.ref_start <= skip_position-1 <= amino_alignment.ref_end:
-                        conseq_pos = coord2conseq[(skip_position - 1 - start_pos) // 3]
-                        if has_skipped_nucleotide:
-                            skipped_nuc = \
-                                self.reading_frames[amino_alignment.reading_frame][conseq_pos + 1].nucleotides[0]
-                        else:
-                            skipped_nuc = SeedNucleotide()
-                            coverage = self.get_deletion_coverage(conseq_pos)
-                            skipped_nuc.count_nucleotides('-', coverage)
-                    else:
-                        skipped_nuc = None
-                    self.update_report_amino(coord_index,
-                                             report_aminos,
-                                             report_nucleotides,
-                                             seed_amino,
-                                             start_pos,
-                                             repeat_position=repeat_position,
-                                             skip_position=skip_position,
-                                             skipped_nuc=skipped_nuc,)
-                if prev_consensus_nuc_index is None:
-                    coordinate_inserts.clear()
-                else:
-                    coordinate_inserts = {i
-                                          for i in coordinate_inserts
-                                          if i <= prev_consensus_nuc_index}
-                self.inserts.update(coordinate_inserts)
+                self.parse_match(amino_alignment,
+                                 amino_ref,
+                                 report_aminos,
+                                 report_nucleotides,
+                                 start_pos,
+                                 repeat_position,
+                                 skip_position,
+                                 has_skipped_nucleotide)
 
     @staticmethod
     def update_report_amino(coord_index: int,
@@ -706,6 +593,155 @@ class ConsensusAligner:
                     report_nuc_index += 1
             report_nuc = report_nucleotides[report_nuc_index]
             report_nuc.seed_nucleotide.add(seed_nuc)
+
+    def parse_deletion(self,
+                       amino_alignment,
+                       amino_ref,
+                       report_aminos,
+                       report_nucleotides,
+                       start_pos,
+                       repeat_position,
+                       skip_position):
+        coverage = self.get_deletion_coverage(
+            amino_alignment.query_start)
+        seed_amino = SeedAmino(None)
+        seed_amino.count_aminos('---', coverage)
+
+        # Start index within region
+        del_start_nuc_index = amino_alignment.ref_start - start_pos + 1
+        del_end_nuc_index = amino_alignment.ref_end - start_pos
+        # Calculate amino index. amino_alignment is already trimmed to
+        # be between start_pos and end_pos, but HIV's vpr has an extra
+        # base that can roll over to an extra amino acid. Trim to length
+        # of amino reference.
+        del_start_amino_index = min(del_start_nuc_index // 3,
+                                    len(amino_ref) - 1)
+        del_end_amino_index = min(del_end_nuc_index // 3,
+                                  len(amino_ref) - 1)
+        for coord_index in count(del_start_amino_index):
+            if coord_index == del_start_amino_index:
+                start_codon_nuc = del_start_nuc_index % 3
+                trimmed_seed_amino = SeedAmino(None)
+                trimmed_seed_amino.add(seed_amino, start_codon_nuc)
+                trimmed_seed_amino.consensus_nuc_index = (
+                        amino_alignment.query_start -
+                        start_codon_nuc)
+            elif coord_index == del_end_amino_index:
+                end_codon_nuc = del_end_nuc_index % 3
+                trimmed_seed_amino = SeedAmino(None)
+                trimmed_seed_amino.add(seed_amino, 0, end_codon_nuc)
+            else:
+                trimmed_seed_amino = seed_amino
+            self.update_report_amino(coord_index,
+                                     report_aminos,
+                                     report_nucleotides,
+                                     trimmed_seed_amino,
+                                     start_pos,
+                                     repeat_position=repeat_position,
+                                     skip_position=skip_position)
+            if coord_index == del_end_amino_index:
+                break
+
+    def parse_insertion(self, amino_alignment, start_pos, end_pos):
+        ref_nuc_index = amino_alignment.ref_start
+        consensus_nuc_index = amino_alignment.query_start + self.consensus_offset - 1
+        section_size = (amino_alignment.query_end - amino_alignment.query_start) // 3
+        for _ in range(section_size):
+            if start_pos - 1 <= ref_nuc_index < end_pos:
+                self.inserts.add(consensus_nuc_index)
+            consensus_nuc_index += 3
+
+    def parse_match(self,
+                    amino_alignment,
+                    amino_ref,
+                    report_aminos,
+                    report_nucleotides,
+                    start_pos,
+                    repeat_position,
+                    skip_position,
+                    has_skipped_nucleotide):
+        region_seed_aminos = self.reading_frames[amino_alignment.reading_frame]
+        coord2conseq = amino_alignment.map_amino_sequences()
+
+        coordinate_inserts = {seed_amino.consensus_nuc_index
+                              for seed_amino in region_seed_aminos}
+        prev_conseq_index = None
+        prev_consensus_nuc_index = None
+        max_conseq_index = max(coord2conseq.values())
+        for coord_index in range(len(amino_ref)):
+            conseq_index = coord2conseq.get(coord_index)
+            if conseq_index is None:
+                seed_amino = SeedAmino(None)
+                if (prev_conseq_index is not None and
+                        prev_conseq_index < max_conseq_index):
+                    prev_seed_amino = region_seed_aminos[prev_conseq_index]
+                    prev_count = sum(prev_seed_amino.counts.values())
+                    prev_count += prev_seed_amino.deletions
+                    next_seed_amino = region_seed_aminos[prev_conseq_index + 1]
+                    next_count = sum(next_seed_amino.counts.values())
+                    next_count += next_seed_amino.deletions
+                    min_count = min(prev_count, next_count)
+                    seed_amino.deletions = min_count
+                    for nuc in seed_amino.nucleotides:
+                        nuc.count_nucleotides('-', min_count)
+            else:
+                seed_amino = region_seed_aminos[conseq_index]
+                consensus_nuc_index = seed_amino.consensus_nuc_index
+                if consensus_nuc_index < amino_alignment.query_start:
+                    start_codon_nuc = max(0,
+                                          amino_alignment.query_start -
+                                          consensus_nuc_index)
+                    end_codon_nuc = 2
+                    seed_amino2 = SeedAmino(None)
+                    seed_amino2.add(seed_amino,
+                                    start_codon_nuc,
+                                    end_codon_nuc)
+                    seed_amino = seed_amino2
+                if amino_alignment.query_end < consensus_nuc_index + 3:
+                    start_codon_nuc = 0
+                    end_codon_nuc = (amino_alignment.query_end -
+                                     consensus_nuc_index - 1)
+                    seed_amino2 = SeedAmino(None)
+                    seed_amino2.add(seed_amino,
+                                    start_codon_nuc,
+                                    end_codon_nuc)
+                    seed_amino = seed_amino2
+                if prev_conseq_index is None:
+                    coordinate_inserts = {i
+                                          for i in coordinate_inserts
+                                          if i >= consensus_nuc_index}
+                prev_conseq_index = conseq_index
+
+            if seed_amino.consensus_nuc_index is not None:
+                coordinate_inserts.remove(seed_amino.consensus_nuc_index)
+                prev_consensus_nuc_index = seed_amino.consensus_nuc_index
+            if skip_position is not None and coord_index == (skip_position - start_pos) // 3 and \
+                    amino_alignment.ref_start <= skip_position - 1 <= amino_alignment.ref_end:
+                conseq_pos = coord2conseq[(skip_position - 1 - start_pos) // 3]
+                if has_skipped_nucleotide:
+                    skipped_nuc = \
+                        self.reading_frames[amino_alignment.reading_frame][conseq_pos + 1].nucleotides[0]
+                else:
+                    skipped_nuc = SeedNucleotide()
+                    coverage = self.get_deletion_coverage(conseq_pos)
+                    skipped_nuc.count_nucleotides('-', coverage)
+            else:
+                skipped_nuc = None
+            self.update_report_amino(coord_index,
+                                     report_aminos,
+                                     report_nucleotides,
+                                     seed_amino,
+                                     start_pos,
+                                     repeat_position=repeat_position,
+                                     skip_position=skip_position,
+                                     skipped_nuc=skipped_nuc, )
+        if prev_consensus_nuc_index is None:
+            coordinate_inserts.clear()
+        else:
+            coordinate_inserts = {i
+                                  for i in coordinate_inserts
+                                  if i <= prev_consensus_nuc_index}
+        self.inserts.update(coordinate_inserts)
 
     def build_nucleotide_report(self,
                                 start_pos: int,


### PR DESCRIPTION
Main change: parse large insertions (>30 bases) in translated regions and add unit tests for all cases of insertions in translated regions.
Some other cosmetic changes to make the `build_amino_report` function a little smaller.