### PR TITLE
V7.15.4 bug fixes

### DIFF
--- a/micall/drivers/sample.py
+++ b/micall/drivers/sample.py
@@ -262,7 +262,7 @@ class Sample:
                         conseq_all_csv=(self.conseq_all_csv, 'w'),
                         conseq_stitched_csv=(self.conseq_stitched_csv, 'w') if use_denovo else None,
                         minimap_hits_csv=(self.minimap_hits_csv, 'w'),
-                        alignments_csv=(self.alignment_csv, 'w'),
+                        alignments_csv=(self.alignments_csv, 'w'),
                         alignments_unmerged_csv=(self.alignments_unmerged_csv, 'w'),
                         alignments_intermediate_csv=(self.alignments_intermediate_csv, 'w'),
                         alignments_overall_csv=(self.alignments_overall_csv, 'w')) as opened_files:

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -378,7 +378,11 @@ class ConsensusAligner:
                     if action != CigarActions.DELETE:
                         amino_alignment.query_start += start_shift
                         amino_alignment.query_end -= end_shift
-                    amino_sections.append(amino_alignment)
+                    alignment_size = amino_alignment.ref_end - amino_alignment.ref_start
+                    if action == CigarActions.MATCH and alignment_size <= 0:
+                        pass
+                    else:
+                        amino_sections.append(amino_alignment)
                 query_progress = query_end
             if repeat_pos is not None:
                 for i, amino_alignment in enumerate(amino_sections):
@@ -741,9 +745,6 @@ class ConsensusAligner:
                               for seed_amino in region_seed_aminos}
         prev_conseq_index = None
         prev_consensus_nuc_index = None
-        if len(coord2conseq) == 0:
-            logger.warning(f"Empty match? Start pos {start_pos}, coordinates {self.coordinate_name}")
-            return
         max_conseq_index = max(coord2conseq.values())
         for coord_index in range(len(amino_ref)):
             conseq_index = coord2conseq.get(coord_index)

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -372,11 +372,12 @@ class ConsensusAligner:
                                       query_progress -
                                       amino_alignment.query_start -
                                       self.consensus_offset)
-                    amino_alignment.ref_start += start_shift
-                    amino_alignment.query_start += start_shift
                     end_shift = max(0, amino_alignment.ref_end - end_pos)
+                    amino_alignment.ref_start += start_shift
                     amino_alignment.ref_end -= end_shift
-                    amino_alignment.query_end -= end_shift
+                    if action != CigarActions.DELETE:
+                        amino_alignment.query_start += start_shift
+                        amino_alignment.query_end -= end_shift
                     amino_sections.append(amino_alignment)
                 query_progress = query_end
             if repeat_pos is not None:
@@ -740,6 +741,9 @@ class ConsensusAligner:
                               for seed_amino in region_seed_aminos}
         prev_conseq_index = None
         prev_consensus_nuc_index = None
+        if len(coord2conseq) == 0:
+            logger.warning(f"Empty match? Start pos {start_pos}, coordinates {self.coordinate_name}")
+            return
         max_conseq_index = max(coord2conseq.values())
         for coord_index in range(len(amino_ref)):
             conseq_index = coord2conseq.get(coord_index)

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -5,6 +5,7 @@ from itertools import count
 from operator import attrgetter
 import csv
 import os
+import logging
 
 from gotoh import align_it, align_it_aa
 from mappy import Alignment, Aligner
@@ -14,6 +15,8 @@ from micall.utils.report_amino import SeedAmino, ReportAmino, ReportNucleotide, 
 
 # A section between reading frame shifts must be at least this long to be split.
 from micall.utils.translation import translate
+
+logger = logging.getLogger(__name__)
 
 MINIMUM_READING_FRAME_SHIFT = 30
 # Minimum aminos in a section between reading frame shifts to be split.
@@ -555,9 +558,13 @@ class ConsensusAligner:
         return seed_amino.nucleotides[consensus_nuc_index % 3]
 
     def get_deletion_coverage(self, consensus_nuc_index):
-        prev_nuc = self.get_seed_nuc(consensus_nuc_index)
-        next_nuc = self.get_seed_nuc(consensus_nuc_index + 1)
-        coverage = min(prev_nuc.get_coverage(), next_nuc.get_coverage())
+        try:
+            prev_nuc = self.get_seed_nuc(consensus_nuc_index)
+            next_nuc = self.get_seed_nuc(consensus_nuc_index + 1)
+            coverage = min(prev_nuc.get_coverage(), next_nuc.get_coverage())
+        except IndexError:
+            coverage = 0
+            logger.warning(f"Could not get deletion coverage for consensus index {consensus_nuc_index}")
         return coverage
 
     def build_amino_report(self,
@@ -783,14 +790,19 @@ class ConsensusAligner:
                 prev_consensus_nuc_index = seed_amino.consensus_nuc_index
             if skip_position is not None and coord_index == (skip_position - start_pos) // 3 and \
                     amino_alignment.ref_start <= skip_position - 1 <= amino_alignment.ref_end:
-                conseq_pos = coord2conseq[(skip_position - 1 - start_pos) // 3]
-                if has_skipped_nucleotide:
-                    skipped_nuc = \
-                        self.reading_frames[amino_alignment.reading_frame][conseq_pos + 1].nucleotides[0]
+                conseq_pos = coord2conseq.get((skip_position - 1 - start_pos) // 3)
+                if conseq_pos is not None:
+                    if has_skipped_nucleotide:
+                        skipped_nuc = \
+                            self.reading_frames[amino_alignment.reading_frame][conseq_pos + 1].nucleotides[0]
+                    else:
+                        skipped_nuc = SeedNucleotide()
+                        coverage = self.get_deletion_coverage(conseq_pos)
+                        skipped_nuc.count_nucleotides('-', coverage)
                 else:
+                    logger.warning("No conseq position found for skip pos, "
+                                   f"because coord2conseq has no entry for {(skip_position - 1 - start_pos) // 3}")
                     skipped_nuc = SeedNucleotide()
-                    coverage = self.get_deletion_coverage(conseq_pos)
-                    skipped_nuc.count_nucleotides('-', coverage)
             else:
                 skipped_nuc = None
             self.update_report_amino(coord_index,

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -789,7 +789,7 @@ class ConsensusAligner:
                 coordinate_inserts.remove(seed_amino.consensus_nuc_index)
                 prev_consensus_nuc_index = seed_amino.consensus_nuc_index
             if skip_position is not None and coord_index == (skip_position - start_pos) // 3 and \
-                    amino_alignment.ref_start < skip_position - 1 < amino_alignment.ref_end:
+                    amino_alignment.ref_start < skip_position - 1 <= amino_alignment.ref_end:
                 conseq_pos = coord2conseq.get((skip_position - 1 - start_pos) // 3)
                 if conseq_pos is not None:
                     if has_skipped_nucleotide:

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -789,7 +789,7 @@ class ConsensusAligner:
                 coordinate_inserts.remove(seed_amino.consensus_nuc_index)
                 prev_consensus_nuc_index = seed_amino.consensus_nuc_index
             if skip_position is not None and coord_index == (skip_position - start_pos) // 3 and \
-                    amino_alignment.ref_start <= skip_position - 1 <= amino_alignment.ref_end:
+                    amino_alignment.ref_start < skip_position - 1 < amino_alignment.ref_end:
                 conseq_pos = coord2conseq.get((skip_position - 1 - start_pos) // 3)
                 if conseq_pos is not None:
                     if has_skipped_nucleotide:
@@ -800,8 +800,6 @@ class ConsensusAligner:
                         coverage = self.get_deletion_coverage(conseq_pos)
                         skipped_nuc.count_nucleotides('-', coverage)
                 else:
-                    logger.warning("No conseq position found for skip pos, "
-                                   f"because coord2conseq has no entry for {(skip_position - 1 - start_pos) // 3}")
                     skipped_nuc = SeedNucleotide()
             else:
                 skipped_nuc = None

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -214,7 +214,7 @@ class ConsensusAligner:
             self.overall_alignments_writer = None
 
     @staticmethod
-    def _create_alignments_writer(alignments_file, different_columns = None):
+    def _create_alignments_writer(alignments_file, different_columns=None):
         columns = different_columns or ["coordinate_name",
                                         "action",
                                         "query_start",

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -455,7 +455,11 @@ def compare_consensus(sample: Sample,
                     last_codon = ''
                     for nuc in target_nucs[-3:]:
                         last_codon = last_codon + nuc
-                    if translate(last_codon) == '*':
+                    try:
+                        last_amino = translate(last_codon)
+                    except KeyError:
+                        last_amino = 'X'
+                    if last_amino == '*':
                         target_details = target_details[:-3]
             for source_item, target_item in zip_longest(source_details,
                                                         target_details,


### PR DESCRIPTION
Some bug fixes that caused samples to fail.
Specifically:
- Don't use an amino alignment that's a match, if its size is equal to or lower than zero (this can happen if there are overlapping matches and the query progress is already past the end of the region, particularly for very small regions like ORF8).
- Don't apply an end or start shift to the reference coordinates for deletions (this was causing troubles for deletions that extended past the ends of a region)