### PR TITLE
Avoid empty `hivseqinr_results` folder

### DIFF
--- a/micall/monitor/kive_watcher.py
+++ b/micall/monitor/kive_watcher.py
@@ -709,9 +709,9 @@ class KiveWatcher:
             sample_name = trim_name(sample_name)
             source_path = scratch_path / sample_name / (archive_name + '.tar')
             try:
-                sample_target_path = output_path / sample_name
-                sample_target_path.mkdir(exist_ok=True)
                 with tarfile.open(source_path) as f:
+                    sample_target_path = output_path / sample_name
+                    sample_target_path.mkdir(exist_ok=True)
                     for source_info in f:
                         filename = os.path.basename(source_info.name)
                         target_path = sample_target_path / filename

--- a/micall/tests/test_kive_watcher.py
+++ b/micall/tests/test_kive_watcher.py
@@ -3007,6 +3007,7 @@ def test_collate_denovo_results(raw_data_with_two_samples, default_config, mock_
 
     expected_cascade_path = version_folder / "denovo" / "cascade.csv"
     expected_done_path = version_folder / "denovo" / "doneprocessing"
+    proviral_path = version_folder / "denovo" / "hivseqinr_results"
 
     main_scratch_path = version_folder / "scratch"
     main_scratch_path.mkdir()
@@ -3029,6 +3030,7 @@ def test_collate_denovo_results(raw_data_with_two_samples, default_config, mock_
     assert expected_cascade_path.exists()
     assert expected_done_path.exists()
     assert main_scratch_path.exists()
+    assert not proviral_path.exists()
 
 
 def test_collate_mixed_hcv_results(raw_data_with_two_samples, default_config, mock_open_kive):


### PR DESCRIPTION
When running the denovo pipeline, a `hivseqinr_results` folder was created within the `denovo` folder, which contained subfolders for each sample, but they would all be empty (even if the proviral pipeline was also run). We don't need this folder, because the proviral results are downloaded to the `proviral` folder. It was created because we try to download all possible output files from kive for each pipeline, and for al tarfiles we create folders with subfolders for each sample. We later delete this folder if it is empty, but because of the sample subfolders it was not empty anymore. By changing the order in which the sample subfolders are created, this will now be avoided - if the tarfile does not exist, the sample subfolders will not be created and the empty directory will be removed.