### PR TITLE
Cache build dependencies from kmc website

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,17 +19,10 @@ jobs:
       - name: Install IVA assembler dependencies
         run: |
           sudo apt-get install -qq zlib1g-dev libncurses5-dev libncursesw5-dev mummer ncbi-blast+
-          echo Changing directory
           cd ~/bin
-          echo Starting wget
-          wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc
-          wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc_dump
-          echo Finished wget
-          # Server doesn't support HTTPS, so check for changed files.
-          echo "\
-            db1935884aec2d23d4d623ff85eb4eae8d7a946c9ee0c33ea1818215c40d3099  kmc
-            34a97db2dab5fdae0276d2589c940142813e9cd87ae10e5e2dd37ed3545b4436  kmc_dump" | sha256sum --check
-          chmod +x kmc kmc_dump
+          echo Try installing kmc with apt
+          sudo apt-get install kmc
+          echo Finished kmc installation
           wget -q https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1.3.1.tar.bz2
           tar -xf samtools-1.3.1.tar.bz2 --no-same-owner --bzip2
           cd samtools-1.3.1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,9 +20,13 @@ jobs:
         run: |
           sudo apt-get install -qq zlib1g-dev libncurses5-dev libncursesw5-dev mummer ncbi-blast+
           cd ~/bin
-          echo Try installing kmc with apt
-          sudo apt-get install kmc
+          echo Get kmc from release
+          # Original sources: http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc
+          # http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc_dump
+          wget -q https://github.com/cfe-lab/MiCall/releases/download/v7.15.5/kmc
+          wget -q https://github.com/cfe-lab/MiCall/releases/download/v7.15.5/kmc_dump
           echo Finished kmc installation
+          chmod +x kmc kmc_dump
           wget -q https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1.3.1.tar.bz2
           tar -xf samtools-1.3.1.tar.bz2 --no-same-owner --bzip2
           cd samtools-1.3.1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,9 @@ jobs:
 
       - name: Install IVA assembler dependencies
         run: |
+          echo Starting apt-get install
           sudo apt-get install -qq zlib1g-dev libncurses5-dev libncursesw5-dev mummer ncbi-blast+
+          echo Done with apt-get install
           cd ~/bin
           wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc
           wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc_dump

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,12 +20,10 @@ jobs:
         run: |
           sudo apt-get install -qq zlib1g-dev libncurses5-dev libncursesw5-dev mummer ncbi-blast+
           cd ~/bin
-          echo Get kmc from release
           # Original sources: http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc
           # http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc_dump
           wget -q https://github.com/cfe-lab/MiCall/releases/download/v7.15.5/kmc
           wget -q https://github.com/cfe-lab/MiCall/releases/download/v7.15.5/kmc_dump
-          echo Finished kmc installation
           chmod +x kmc kmc_dump
           wget -q https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1.3.1.tar.bz2
           tar -xf samtools-1.3.1.tar.bz2 --no-same-owner --bzip2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,12 +18,13 @@ jobs:
 
       - name: Install IVA assembler dependencies
         run: |
-          echo Starting apt-get install
           sudo apt-get install -qq zlib1g-dev libncurses5-dev libncursesw5-dev mummer ncbi-blast+
-          echo Done with apt-get install
+          echo Changing directory
           cd ~/bin
+          echo Starting wget
           wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc
           wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc_dump
+          echo Finished wget
           # Server doesn't support HTTPS, so check for changed files.
           echo "\
             db1935884aec2d23d4d623ff85eb4eae8d7a946c9ee0c33ea1818215c40d3099  kmc

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,8 @@ ENV PATH $PATH:/opt/bowtie2
 ## Installing IVA dependencies
 RUN apt-get install -q -y zlib1g-dev libncurses5-dev libncursesw5-dev && \
     cd /bin && \
-    wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc && \
-    wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc_dump && \
+    wget -q https://github.com/cfe-lab/MiCall/releases/download/v7.15.5/kmc && \
+    wget -q https://github.com/cfe-lab/MiCall/releases/download/v7.15.5/kmc_dump && \
     chmod +x kmc kmc_dump && \
     cd /opt && \
     wget -q https://sourceforge.net/projects/mummer/files/mummer/3.23/MUMmer3.23.tar.gz && \

--- a/Singularity
+++ b/Singularity
@@ -96,8 +96,8 @@ From: centos:7
     echo ===== Installing IVA dependencies ===== >/dev/null
     yum install -q -y tcsh ncurses-devel zlib-devel
     cd /bin
-    wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc
-    wget -q http://sun.aei.polsl.pl/kmc/download-2.1.1/linux/kmc_dump
+    wget -q https://github.com/cfe-lab/MiCall/releases/download/v7.15.5/kmc
+    wget -q https://github.com/cfe-lab/MiCall/releases/download/v7.15.5/kmc_dump
     chmod +x kmc kmc_dump
     cd /opt
     wget -q https://sourceforge.net/projects/mummer/files/mummer/3.23/MUMmer3.23.tar.gz

--- a/docs/design/assembly.md
+++ b/docs/design/assembly.md
@@ -95,7 +95,7 @@ If the seed extended to at least three quarters of the seed stop length, it's a
 success and IVA will move on to the next step. If not, it records the failed
 seed and starts again with the next most common k-mer as a new seed.
 
-[KMC]: https://sun.aei.polsl.pl/REFRESH/index.php?page=projects&project=kmc&subpage=about
+[KMC]: https://github.com/refresh-bio/KMC
 
 
 ## Extending with Read Pairs


### PR DESCRIPTION
Since the kmc website seems to be down, we will now retrieve the lmc and lmc_dump source files from the newest release.