### PR TITLE
Update release comparison script

### DIFF
--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -666,6 +666,7 @@ def main():
                                chunksize=args.workers)
         except BrokenProcessPool:
             print("Broken Process Pool - probably the memory usage is too high. Try again with fewer workers!")
+            raise
         scenario_summaries = defaultdict(list)
         i = 0
         all_consensus_distances = []

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -456,17 +456,11 @@ def compare_consensus(sample: Sample,
             if MICALL_VERSION == '7.15':
                 if region.split('-')[-1] == 'NS5b':
                     NS5b_nucs = [nuc for nuc, row in target_details]
-                    old_nucs = [nuc for nuc, row in source_details]
-                    first_pos_new = int(target_details[0][1]['refseq.nuc.pos'])
-                    first_pos_old = int(source_details[0][1]['refseq.nuc.pos'])
-                    print(f"{sample.name}, old: {first_pos_old}, new {first_pos_new}")
-                    if first_pos_old < first_pos_new:
-                        for pos in range(first_pos_new - first_pos_old):
-                            if old_nucs[pos] == 'x':
-                                source_details = source_details[1:]
-                            else:
-                                print(f"breaking at pos {pos}")
-                                break
+                    new_positions = [row['refseq.nuc.pos'] for nuc, row in target_details]
+                    old_positions = [row['refseq.nuc.pos'] for nuc, row in target_details]
+                    for position in old_positions:
+                        if position not in new_positions:
+                            target_details.insert(position-1, ('x', {'refseq.nuc.pos': position, 'coverage': '0'}))
                     last_codon = ''
                     for nuc in NS5b_nucs[-3:]:
                         last_codon = last_codon + nuc

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -67,6 +67,7 @@ def parse_args():
                         help='Testing RAWDATA folder to compare with.')
     parser.add_argument('--workers',
                         default=50,
+                        type=int,
                         help='Number of parallel workers to process the samples.')
     return parser.parse_args()
 

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -330,23 +330,19 @@ def compare_coverage(sample, diffs, scenarios_reported, scenarios):
          target_key_pos) = target_scores.get(key, ('-', None, None))
         source_compare = '-' if source_score == '1' else source_score
         target_compare = '-' if target_score == '1' else target_score
-        if (source_compare == '-' and
-                sample.name.startswith('90308A') and
-                MICALL_VERSION == '7.11'):
-            # One sample failed in 7.10.
-            continue
-        elif MICALL_VERSION == '7.15' and key[0] == 'HIVGHA':
-            # ignore HIVGHA project code
-            continue
-        elif MICALL_VERSION == '7.15' and target_seed is None:
-            project, region = key
-            hivgha_result = target_scores.get(('HIVGHA', region))
-            if hivgha_result is not None:
-                # retrieve HIVGHA project code results for comparison
-                (target_score, target_seed, target_key_pos) = hivgha_result
-                if target_seed in ('HIV1-CRF02_AG-GH-AB286855-seed', 'HIV1-CRF06_CPX-GH-AB286851-seed'):
-                    # ignore samples that switched to the new HIVGHA seeds
-                    continue
+        if MICALL_VERSION == '7.15':
+            if key[0] == 'HIVGHA':
+                # ignore HIVGHA project code
+                continue
+            elif target_seed is None:
+                project, region = key
+                hivgha_result = target_scores.get(('HIVGHA', region))
+                if hivgha_result is not None:
+                    # retrieve HIVGHA project code results for comparison
+                    (target_score, target_seed, target_key_pos) = hivgha_result
+                    if target_seed in ('HIV1-CRF02_AG-GH-AB286855-seed', 'HIV1-CRF06_CPX-GH-AB286851-seed'):
+                        # ignore samples that switched to the new HIVGHA seeds
+                        continue
         if source_compare != target_compare:
             project, region = key
             message = '{}:{} coverage: {} {} {} => {}'.format(
@@ -588,11 +584,6 @@ def filter_consensus_sequences(files, use_denovo):
     coverage_scores = files.coverage_scores
     if not (region_consensus and coverage_scores):
         return {}
-
-    if MICALL_VERSION == '7.14':
-        coverage_scores = [row
-                           for row in coverage_scores
-                           if row['project'] != 'SARSCOV2']
 
     if MICALL_VERSION == '7.15':
         coverage_scores = [row

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -335,11 +335,13 @@ def compare_coverage(sample, diffs, scenarios_reported, scenarios):
                 MICALL_VERSION == '7.11'):
             # One sample failed in 7.10.
             pass
-        elif target_seed in ('HIV1-CRF02_AG-GH-AB286855-seed', 'HIV1-CRF06_CPX-GH-AB286851-seed'):
+        elif MICALL_VERSION == '7.15' and target_seed is None:
             project, region = key
-            if project != 'HIVGHA':
-                # these two seeds only belong to the HIVGHA project code
-                continue
+            hivgha_result = target_scores.get(('HIVGHA', region))
+            if hivgha_result is not None:
+                hivgha_seed = hivgha_result(1)
+                if hivgha_seed in ('HIV1-CRF02_AG-GH-AB286855-seed', 'HIV1-CRF06_CPX-GH-AB286851-seed'):
+                    continue
         elif source_compare != target_compare:
             project, region = key
             message = '{}:{} coverage: {} {} {} => {}'.format(
@@ -431,21 +433,29 @@ def compare_consensus(sample: Sample,
     cutoff = MAX_CUTOFF
     for key in keys:
         seed, region = key
-        if MICALL_VERSION == '7.15' and region in ('HIV1B-tat',
-                                                   'SARS-CoV-2-nsp11',
-                                                   "SARS-CoV-2-TRS-B-1",
-                                                   "SARS-CoV-2-TRS-B-2",
-                                                   "SARS-CoV-2-TRS-B-3",
-                                                   "SARS-CoV-2-TRS-B-4",
-                                                   "SARS-CoV-2-TRS-B-5",
-                                                   "SARS-CoV-2-TRS-B-6",
-                                                   "SARS-CoV-2-TRS-B-7",
-                                                   "SARS-CoV-2-TRS-B-8",
-                                                   "SARS-CoV-2-TRS-B-9"):
-            continue
+        if MICALL_VERSION == '7.15':
+            if region in ('HIV1B-tat',
+                          'SARS-CoV-2-nsp11',
+                          "SARS-CoV-2-TRS-B-1",
+                          "SARS-CoV-2-TRS-B-2",
+                          "SARS-CoV-2-TRS-B-3",
+                          "SARS-CoV-2-TRS-B-4",
+                          "SARS-CoV-2-TRS-B-5",
+                          "SARS-CoV-2-TRS-B-6",
+                          "SARS-CoV-2-TRS-B-7",
+                          "SARS-CoV-2-TRS-B-8",
+                          "SARS-CoV-2-TRS-B-9"):
+                continue
+            if seed in ('HIV1-CRF02_AG-GH-AB286855-seed', 'HIV1-CRF06_CPX-GH-AB286851-seed'):
+                # handled below
+                continue
         primer_tracker = primer_trackers.get(seed)
         source_details = source_seqs.get(key)
         target_details = target_seqs.get(key)
+        if MICALL_VERSION == '7.15' and target_details is None:
+            # match up with new HIVGHA seeds
+            target_details = target_seqs.get(('HIV1-CRF02_AG-GH-AB286855-seed', region)) or \
+                target_seqs.get(('HIV1-CRF06_CPX-GH-AB286851-seed', region))
         source_nucs = []
         target_nucs = []
         if source_details is None:

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -455,9 +455,20 @@ def compare_consensus(sample: Sample,
                          'coverage': '0'}
             if MICALL_VERSION == '7.15':
                 if region.split('-')[-1] == 'NS5b':
-                    target_nucs = [nuc for nuc, row in target_details]
+                    NS5b_nucs = [nuc for nuc, row in target_details]
+                    old_nucs = [nuc for nuc, row in source_details]
+                    first_pos_new = int(target_details[0][1]['refseq.nuc.pos'])
+                    first_pos_old = int(source_details[0][1]['refseq.nuc.pos'])
+                    print(f"{sample.name}, old: {first_pos_old}, new {first_pos_new}")
+                    if first_pos_old < first_pos_new:
+                        for pos in range(first_pos_new - first_pos_old):
+                            if old_nucs[pos] == 'x':
+                                source_details = source_details[1:]
+                            else:
+                                print(f"breaking at pos {pos}")
+                                break
                     last_codon = ''
-                    for nuc in target_nucs[-3:]:
+                    for nuc in NS5b_nucs[-3:]:
                         last_codon = last_codon + nuc
                     try:
                         last_amino = translate(last_codon)

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -335,7 +335,7 @@ def compare_coverage(sample, diffs, scenarios_reported, scenarios):
                 MICALL_VERSION == '7.11'):
             # One sample failed in 7.10.
             continue
-        elif MICALL_VERSION == '7.15' and key(0) == 'HIVGHA':
+        elif MICALL_VERSION == '7.15' and key[0] == 'HIVGHA':
             # ignore HIVGHA project code
             continue
         elif MICALL_VERSION == '7.15' and target_seed is None:
@@ -452,7 +452,7 @@ def compare_consensus(sample: Sample,
                           "SARS-CoV-2-TRS-B-9"):
                 continue
             if seed in ('HIV1-CRF02_AG-GH-AB286855-seed', 'HIV1-CRF06_CPX-GH-AB286851-seed'):
-                # handled below
+                # ignore new HIVGHA seeds
                 continue
         primer_tracker = primer_trackers.get(seed)
         source_details = source_seqs.get(key)

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -292,7 +292,7 @@ def map_coverage(coverage_scores):
         filtered_scores = {
             (project, region): scores
             for (project, region), scores in filtered_scores.items()
-            if project not in ('HIVB', 'HIVGHA') and region not in ('HIVB-tat', 'SARS-CoV-2-nsp11')}
+            if project not in ('HIVB', 'HIVGHA') and region not in ('HIV1B-tat', 'SARS-CoV-2-nsp11')}
 
     return filtered_scores
 
@@ -335,6 +335,11 @@ def compare_coverage(sample, diffs, scenarios_reported, scenarios):
                 MICALL_VERSION == '7.11'):
             # One sample failed in 7.10.
             pass
+        elif target_seed in ('HIV1-CRF02_AG-GH-AB286855-seed', 'HIV1-CRF06_CPX-GH-AB286851-seed'):
+            project, region = key
+            if project != 'HIVGHA':
+                # these two seeds only belong to the HIVGHA project code
+                continue
         elif source_compare != target_compare:
             project, region = key
             message = '{}:{} coverage: {} {} {} => {}'.format(

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -695,6 +695,7 @@ def main():
                                chunksize=args.workers)
         except BrokenProcessPool:
             print("Broken Process Pool - probably the memory usage is too high. Try again with fewer workers!")
+            print("Current number of workers: {args.workers}")
             raise
         scenario_summaries = defaultdict(list)
         i = 0

--- a/release_test_compare.py
+++ b/release_test_compare.py
@@ -456,8 +456,8 @@ def compare_consensus(sample: Sample,
             if MICALL_VERSION == '7.15':
                 if region.split('-')[-1] == 'NS5b':
                     NS5b_nucs = [nuc for nuc, row in target_details]
-                    new_positions = [row['refseq.nuc.pos'] for nuc, row in target_details]
-                    old_positions = [row['refseq.nuc.pos'] for nuc, row in target_details]
+                    new_positions = [int(row['refseq.nuc.pos']) for nuc, row in target_details]
+                    old_positions = [int(row['refseq.nuc.pos']) for nuc, row in source_details]
                     for position in old_positions:
                         if position not in new_positions:
                             target_details.insert(position-1, ('x', {'refseq.nuc.pos': position, 'coverage': '0'}))


### PR DESCRIPTION
- Add some error handling for when the process pool breaks due to insufficient memory and an option to input the number of workers as a command line argument.
- Special case of NS5b consensus comparison: add `x` to uncovered parts in the new version.
- Add special cases for new `HIVGHA` project code and new chimeric seeds that are only used for the `HIVGHA` project code.