### PR TITLE
Roll back mappy to last release's version

### DIFF
--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -2012,7 +2012,7 @@ HIV1-B-FR-K03455-seed,HIV1B-gag,15,494,1073,1862,9,0,0,0,0,0,0,0,0,9"""
 
     report = report_file.getvalue()
     report_lines = report.splitlines()
-    expected_size = 1542
+    expected_size = 1558
     if len(report_lines) != expected_size:
         assert (len(report_lines), report) == (expected_size, '')
 

--- a/micall/tests/test_consensus_aligner.py
+++ b/micall/tests/test_consensus_aligner.py
@@ -463,7 +463,7 @@ def test_start_contig_insertion_minimap2(projects):
                                           r_en=2060,
                                           q_st=0,
                                           q_en=63,
-                                          mapq=8,
+                                          mapq=9,
                                           cigar=[[30, CigarActions.MATCH],
                                                  [3, CigarActions.INSERT],
                                                  [30, CigarActions.MATCH]],

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ PyYAML==6.0
 reportlab==3.6.9
 pysam==0.19.0
 git+https://github.com/cfe-lab/genetracks.git@v0.2.dev0
-mappy==2.24
+mappy==2.17


### PR DESCRIPTION
We're rolling back mappy due to alignment issues in a couple of samples, see #840.