### PR TITLE
Resistance interpretation in NS5b

### DIFF
--- a/docs/design/resistance.md
+++ b/docs/design/resistance.md
@@ -17,10 +17,11 @@ The first quality check is for each region, in the `check_coverage()` function:
 
 That rule has a special case for HCV-NS5b, where it is split in two. The main
 sample gets checked for positions 1-228, and the MIDI sample gets checked for
-positions 231-561.
+positions 231-561. If the MIDI sample failed the coverage check, the sequence
+of the main sample is used up to position 336.
 
 The coverage at all resistance positions is checked in `read_aminos()`. All the
-known resistance positions for the mapped genotype are are checked, and at
+known resistance positions for the mapped genotype are checked, and at
 least one of a sample's gene regions must have coverage of at least 100 on all
 resistance positions, or no report will be generated. There's a special case
 for HCV-NS5b where coverage of at least 100 on all the resistance positions
@@ -30,3 +31,11 @@ each HCV genotype and for HIV.
 
 Anything that doesn't meet these rules should write a row into the
 `resistance_fail.csv` file.
+
+Even if there is a failure, the sample is padded with wild type data in the areas
+that do not have coverage, and passed through the resistance interpretation again.
+After this second interpretation step, we restrict the allowed resistance results,
+to make sure that we do not make a wrong call due to the missing data. If a drug
+has one of the permitted drug results, we will output the new result in the 
+resistance file, otherwise we keep the previous failure result (level 0, 
+'Sequence does not meet quality-control standards').

--- a/micall/resistance/resistance.py
+++ b/micall/resistance/resistance.py
@@ -274,9 +274,8 @@ def read_aminos(amino_rows,
             is_report_required = False
         else:
             std_length = get_std_length(region, genotype, algorithms)
-            if not region.endswith('NS5b'):
-                while len(aminos) < std_length:
-                    aminos.append({})
+            while len(aminos) < std_length:
+                aminos.append({})
             asi_algorithm = algorithms.get(genotype)
             key_positions = asi_algorithm.get_gene_positions(region)
             if not region.endswith('NS5b'):
@@ -521,7 +520,15 @@ def create_consensus_writer(resistance_consensus_csv):
 def interpret(asi, amino_seq, region):
     ref_seq = asi.stds[region]
     # TODO: Make this more general instead of only applying to missing MIDI.
-    is_missing_midi = region.endswith('-NS5b') and len(amino_seq) < len(ref_seq)
+    is_missing_midi = False
+    if region.endswith('-NS5b'):
+        pos = 0
+        # starting at the end of the amino list, find the first amino that is not empty
+        for pos, amino in enumerate(reversed(amino_seq)):
+            if amino != {}:
+                break
+        if len(amino_seq) - pos == 336:
+            is_missing_midi = True
 
     if is_missing_midi:
         amino_seq += [{}] * (len(ref_seq) - len(amino_seq))

--- a/micall/resistance/resistance.py
+++ b/micall/resistance/resistance.py
@@ -17,6 +17,12 @@ from micall.core.aln2counts import AMINO_ALPHABET
 MIN_FRACTION = 0.05  # prevalence of mutations to report
 MIN_COVERAGE = 100
 REPORTED_REGIONS = {'PR', 'RT', 'IN', 'NS3', 'NS5a', 'NS5b'}
+LAST_MAIN_POS = 336  # last position to take from main file if midi is missing
+NS3_END_POS = 181  # positions to check for coverage
+NS5A_END_POS = 101
+NS5B_MAIN_END_POS = 228
+MIDI_START_POS = 231
+MIDI_END_POS = 561
 
 # Rules configuration - remember to update version numbers in genreport.yaml.
 HIV_RULES_PATH = os.path.join(os.path.dirname(__file__), 'HIVDB_9.0.xml')
@@ -103,11 +109,11 @@ def create_fail_writer(fail_csv):
 def check_coverage(region, rows, start_pos=1, end_pos=None):
     if end_pos is None:
         if region.endswith('-NS3'):
-            end_pos = 181
+            end_pos = NS3_END_POS
         elif region.endswith('-NS5a'):
-            end_pos = 101
+            end_pos = NS5A_END_POS
         elif region.endswith('-NS5b'):
-            end_pos = 228
+            end_pos = NS5B_MAIN_END_POS
         else:
             return
     start_coverage = 0
@@ -143,8 +149,8 @@ def combine_aminos(amino_csv, midi_amino_csv, failures: dict):
     """
     is_midi = True
     midi_rows = {}  # {genotype: [row]}
-    midi_start = 231
-    midi_end = 561
+    midi_start = MIDI_START_POS
+    midi_end = MIDI_END_POS
     is_midi_separate = midi_amino_csv.name != amino_csv.name
     if is_midi_separate:
         for (seed, region), rows in groupby(DictReader(midi_amino_csv),
@@ -159,7 +165,7 @@ def combine_aminos(amino_csv, midi_amino_csv, failures: dict):
                 continue
             midi_rows[get_genotype(seed)] = [row
                                              for row in rows
-                                             if 226 < int(row['refseq.aa.pos'])]
+                                             if (NS5B_MAIN_END_POS - 2) < int(row['refseq.aa.pos'])]
     is_midi = False
     for (seed, region), rows in groupby(DictReader(amino_csv),
                                         itemgetter('seed', 'region')):
@@ -226,11 +232,11 @@ def combine_midi_rows(main_rows, midi_rows, seed):
         main_row = main_row_map.get(pos)
         midi_row = midi_row_map.get(pos)
         if midi_row is None:
-            if pos <= 336:
+            if pos <= LAST_MAIN_POS:
                 yield main_row
         elif main_row is None:
             yield midi_row
-        elif (pos <= 336 and
+        elif (pos <= LAST_MAIN_POS and
               int(main_row['coverage']) > int(midi_row['coverage'])):
             yield main_row
         else:
@@ -281,7 +287,7 @@ def read_aminos(amino_rows,
             if not region.endswith('NS5b'):
                 is_report_required = all(aminos[pos-1] for pos in key_positions)
             else:
-                whole_genome_positions = {pos for pos in key_positions if pos < 231}
+                whole_genome_positions = {pos for pos in key_positions if pos < MIDI_START_POS}
                 midi_positions = key_positions - whole_genome_positions
                 is_report_required = (
                     all(pos <= len(aminos) and aminos[pos-1]
@@ -527,7 +533,7 @@ def interpret(asi, amino_seq, region):
         for pos, amino in enumerate(reversed(amino_seq)):
             if amino != {}:
                 break
-        if len(amino_seq) - pos == 336:
+        if len(amino_seq) - pos <= LAST_MAIN_POS:
             is_missing_midi = True
 
     if is_missing_midi:

--- a/micall/resistance/resistance.py
+++ b/micall/resistance/resistance.py
@@ -274,8 +274,9 @@ def read_aminos(amino_rows,
             is_report_required = False
         else:
             std_length = get_std_length(region, genotype, algorithms)
-            while len(aminos) < std_length:
-                aminos.append({})
+            if not region.endswith('NS5b'):
+                while len(aminos) < std_length:
+                    aminos.append({})
             asi_algorithm = algorithms.get(genotype)
             key_positions = asi_algorithm.get_gene_positions(region)
             if not region.endswith('NS5b'):

--- a/micall/tests/test_resistance.py
+++ b/micall/tests/test_resistance.py
@@ -1723,7 +1723,7 @@ NRTI,M41L,0.3,,RT,HIV1B-seed,RT,9.0
 
     def test_hcv(self):
         aminos = [AminoList('HCV6-EUHK2-NS5b',
-                            [{'T': 1.0}] * 591,
+                            [{'T': 1.0}] * 592,
                             '6',
                             'HCV-6a')]
         resistance_csv = StringIO()
@@ -1825,7 +1825,7 @@ drug_class,mutation,prevalence,genotype,region,seed,coord_region,version
 
     def test_hcv_mostly_low_coverage(self):
         aminos = [AminoList('HCV1B-Con1-NS5b',
-                            [{'T': 1.0}] + [{}] * 319 + [{'I': 1.0}] + [{}] * 200,
+                            [{'T': 1.0}] + [{}] * 319 + [{'I': 1.0}] + [{}] * 271,
                             '1B',
                             'HCV-1b')]
         self.check_low_coverage_reports(aminos)


### PR DESCRIPTION
This fixes a bug where a missing MIDI region was not recognised because we had started padding the region with empty amino acids until the region end. The fix is to check for empty amino acids at the end of the region instead of just comparing the length.
I also fixed some unit tests to reflect what the inputs to `write_resistance` now look like, wrote up some more details in the documentation, and made some of the hard-coded region start and end positions global variables.