### PR TITLE
Fix contig plotting bug

### DIFF
--- a/micall/core/plot_contigs.py
+++ b/micall/core/plot_contigs.py
@@ -511,6 +511,9 @@ def build_contig(reader,
 
         arrows = []
         for arrow_start, arrow_end, blast_num in blast_ranges:
+            if arrow_end is None:
+                # Special case where an alignment ends with an insertion: ignore that insertion
+                continue
             arrows.append(Arrow(arrow_start+position_offset,
                                 arrow_end+position_offset,
                                 elevation=-1,

--- a/micall/core/plot_contigs.py
+++ b/micall/core/plot_contigs.py
@@ -466,6 +466,11 @@ def build_contig(reader,
                 contig_row['concordance'] = field_value
         start = contig_rows[0][pos_field]
         end = contig_rows[-1][pos_field]
+        new_final_pos = -1
+        while end is None:
+            # this can happen if the match ends with an insertion. Backtrack to the last position that was not None
+            new_final_pos -= 1
+            end = contig_rows[new_final_pos][pos_field]
         coverage = [0] * (end - start + 1)
         concordance = [0] * (end - start + 1)
         pos = 0

--- a/micall/tests/test_plot_contigs.py
+++ b/micall/tests/test_plot_contigs.py
@@ -586,6 +586,39 @@ Coverage 5x3, 7x3, 8x3
     assert expected_figure == summarize_figure(figure)
 
 
+def test_plot_genome_coverage_insertion_at_end():
+    genome_coverage_csv = StringIO("""\
+contig,coordinates,query_nuc_pos,refseq_nuc_pos,dels,coverage
+1-HCV-1a,HCV1A,1,1,0,5
+1-HCV-1a,HCV1A,2,2,0,5
+1-HCV-1a,HCV1A,3,3,0,7
+1-HCV-1a,HCV1A,4,4,0,5
+1-HCV-1a,HCV1A,5,5,0,5
+1-HCV-1a,HCV1A,6,6,0,5
+contig-1-HCV-1a,HCV1A,1,1,0,,5
+contig-1-HCV-1a,HCV1A,2,2,0,,5
+contig-1-HCV-1a,HCV1A,3,3,0,,5
+contig-1-HCV-1a,HCV1A,4,4,0,,6
+contig-1-HCV-1a,HCV1A,5,5,0,,6
+contig-1-HCV-1a,HCV1A,6,6,0,,6
+contig-1-HCV-1a,HCV1A,7,,,,
+contig-1-HCV-1a,HCV1A,8,,,,
+contig-1-HCV-1a,HCV1A,9,,,,
+""")
+    expected_figure = """\
+5'[1-341], C[342-914], E1[915-1490], E2[1491-2579], p7[2580-2768], \
+NS2[2769-3419], NS3[3420-5312], NS4b[5475-6257], NS4a[5313-5474], \
+NS5a[6258-7601], NS5b[7602-9377], 3'[9378-9646]
+Coverage 5x2, 7, 5x3
+[1-6], 1-HCV-1a - depth 7(1-9646)
+[1-6], contig-1-HCV-1a(1-9646)
+"""
+
+    figure = build_coverage_figure(genome_coverage_csv)
+
+    assert expected_figure == summarize_figure(figure)
+
+
 def test_plot_genome_coverage_deletion():
     genome_coverage_csv = StringIO("""\
 contig,coordinates,query_nuc_pos,refseq_nuc_pos,ins,dels,coverage,concordance,link


### PR DESCRIPTION
MiCall 7.15 crashes if an alignment ends with an insertion, this PR fixes that bug and adds a unit test reproducing the error.

Closes #887 