### PR TITLE
Small alignments bug fix

### DIFF
--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -395,7 +395,7 @@ class ConsensusAligner:
                         amino_alignment.query_start += start_shift
                         amino_alignment.query_end -= end_shift
                     alignment_size = amino_alignment.ref_end - amino_alignment.ref_start
-                    if action == CigarActions.MATCH and alignment_size <= 0:
+                    if action == CigarActions.MATCH and alignment_size <= 2:
                         pass
                     else:
                         amino_sections.append(amino_alignment)

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -395,7 +395,7 @@ class ConsensusAligner:
                         amino_alignment.query_start += start_shift
                         amino_alignment.query_end -= end_shift
                     alignment_size = amino_alignment.ref_end - amino_alignment.ref_start
-                    if action == CigarActions.MATCH and alignment_size <= 2:
+                    if action == CigarActions.MATCH and alignment_size <= 0:
                         pass
                     else:
                         amino_sections.append(amino_alignment)
@@ -757,6 +757,9 @@ class ConsensusAligner:
                     has_skipped_nucleotide):
         region_seed_aminos = self.reading_frames[amino_alignment.reading_frame]
         coord2conseq = amino_alignment.map_amino_sequences()
+        if not coord2conseq:
+            # coord2conseq is empty (alignment was too small / at region boundary) - there is nothing to do
+            return
 
         coordinate_inserts = {seed_amino.consensus_nuc_index
                               for seed_amino in region_seed_aminos}


### PR DESCRIPTION
We had a bug in MiCall 7.15 where an alignment containing no aligned nucleotides throws an error. There are two options to solve it, see #899. I went with the safer option that keeps all small alignments around, until it turns out that they are in fact useless. But I'm still double checking whether I can actually find a case where such small alignments were actually useful. Feel free to merge if you think this solution is fine, or to wait for the results of my investigation.

Closes #899 