### PR TITLE
Shifted concordance plots

### DIFF
--- a/docs/steps.md
+++ b/docs/steps.md
@@ -284,11 +284,13 @@ Individual files are described after the list of steps.
   * coordinates - the name of the coordinate reference the query was aligned to
   * query_nuc_pos - the one-based nucleotide position within the contig or the remap
     consensus
-  * refseq_nuc_pos - the one-based nucleotide position within the reference
+  * refseq_nuc_pos - the one-based nucleotide position within the reference, used for display - please note that this 
+  is *NOT* the reference position that corresponds to the query positions in the alignment.
   * dels - number of deletions reported at this position
   * coverage - number of reads that aligned to this position, including
     deletions
-  * link - type of link between the contig position and the reference position: 'M' for a match, 'D' for a deletion, 'I' for an insertion, and 'U' for unknown (a section of the contig that didn't map to the reference)
+  * link - type of link between the contig position and the reference position: 'M' for a match, 'D' for a deletion, 
+  'I' for an insertion, and 'U' for unknown (a section of the contig that didn't map to the reference)
 * insertions.csv
   * seed - the name of the contig
   * mixture_cutoff - to be included in a mixture, a variant must make

--- a/micall/core/aln2counts.py
+++ b/micall/core/aln2counts.py
@@ -984,17 +984,13 @@ class SequenceReport(object):
             for length, action in cigar:
                 if action == CigarActions.DELETE:
                     for pos in range(ref_pos+1, ref_pos+length+1):
-                        try:
-                            concordance = self.coord_concordance[pos - 1]
-                        except (IndexError, TypeError):
-                            concordance = None
                         row = dict(contig=contig_name,
                                    coordinates=coordinate_name,
                                    query_nuc_pos=None,
                                    refseq_nuc_pos=pos,
                                    dels=None,
                                    coverage=None,
-                                   concordance=concordance,
+                                   concordance=None,
                                    link='D')
                         self.genome_coverage_writer.writerow(row)
                     ref_pos += length
@@ -1026,7 +1022,7 @@ class SequenceReport(object):
                     else:
                         if action != CigarActions.INSERT:
                             try:
-                                concordance = self.coord_concordance[ref_pos - 1]
+                                concordance = self.coord_concordance[offset_seq_pos - 1]
                             except (IndexError, TypeError):
                                 concordance = None
                         else:

--- a/micall/core/plot_contigs.py
+++ b/micall/core/plot_contigs.py
@@ -650,11 +650,15 @@ def main():
                         type=FileType())
     parser.add_argument('genome_coverage_svg',
                         help='SVG file to plot coverage counts for each contig')
+    parser.add_argument('--concordance',
+                        help='Make concordance plot instead of coverage',
+                        action='store_true')
     args = parser.parse_args()
 
     plot_genome_coverage(args.genome_coverage_csv,
                          args.blast,
-                         args.genome_coverage_svg)
+                         args.genome_coverage_svg,
+                         args.concordance)
     print('Wrote', args.genome_coverage_svg)
 
 

--- a/micall/tests/test_aln2counts_report.py
+++ b/micall/tests/test_aln2counts_report.py
@@ -2760,18 +2760,17 @@ contig,coordinates,query_nuc_pos,refseq_nuc_pos,dels,coverage,concordance,link
 
     expected_middle = """\
 1-my-contig,HIV1-B-FR-K03455-seed,64,159,0,1,0.6,M
-1-my-contig,HIV1-B-FR-K03455-seed,65,160,0,1,0.55,M
-1-my-contig,HIV1-B-FR-K03455-seed,,161,,,0.5,D
-1-my-contig,HIV1-B-FR-K03455-seed,,162,,,0.45,D
-1-my-contig,HIV1-B-FR-K03455-seed,,163,,,0.4,D
-1-my-contig,HIV1-B-FR-K03455-seed,,164,,,0.35,D
-1-my-contig,HIV1-B-FR-K03455-seed,,165,,,0.3,D
+1-my-contig,HIV1-B-FR-K03455-seed,65,160,0,1,0.6,M
+1-my-contig,HIV1-B-FR-K03455-seed,,161,,,,D
+1-my-contig,HIV1-B-FR-K03455-seed,,162,,,,D
+1-my-contig,HIV1-B-FR-K03455-seed,,163,,,,D
+1-my-contig,HIV1-B-FR-K03455-seed,,164,,,,D
+1-my-contig,HIV1-B-FR-K03455-seed,,165,,,,D
 """
 
     report_file = StringIO()
     sequence_report.projects = projects
-    sequence_report.coord_concordance = [None] * 105 + [0.95, 0.9, 0.85, 0.8] + [0.7] * 45 + [0.6] * 5 + \
-                                        [0.55, 0.5, 0.45, 0.4, 0.35, 0.3]
+    sequence_report.coord_concordance = [None] * 5 + [0.95, 0.9, 0.85, 0.8, 0.7] + [None] * 5 + [0.7] * 45 + [0.6] * 5
     sequence_report.write_genome_coverage_header(report_file)
     sequence_report.write_sequence_coverage_counts('1-my-contig',
                                                    hxb2_name,

--- a/micall/tests/test_consensus_aligner.py
+++ b/micall/tests/test_consensus_aligner.py
@@ -830,7 +830,8 @@ def test_count_coord_concordance_short_match():
     {"genotype_references": {"test-region": {"is_nucleotide": true,"reference": ["AGATTTCGATGATTCAGAAGATTTGCATTT"]}}}
     """))
     aligner = ConsensusAligner(projects)
-    aligner.consensus = "AGATTTCGATGATTCAGAAGATTTGCA"
+    aligner.consensus = "AGATTTCGATGATTCTCTTCTAAACGT"
+    # last match position:             ^
     aligner.coordinate_name = 'test-region'
     aligner.alignments = [AlignmentWrapper(r_st=0, r_en=15, q_st=0, q_en=15, cigar=[[15, CigarActions.MATCH]])]
     # as the averaging window (size 20) slides along the query, the concordance decreases from 15/20 = 0.75
@@ -874,7 +875,8 @@ def test_count_coord_concordance_with_insertion():
     aligner.alignments = [AlignmentWrapper(r_st=0, r_en=27, q_st=0, q_en=30, cigar=[[9, CigarActions.MATCH],
                                                                                     [3, CigarActions.INSERT],
                                                                                     [18, CigarActions.MATCH]])]
-    # the insertion decreases the concordance. the last concordance window only includes two of the inserted bases
+    # the insertion decreases the concordance to 17/20 = 0.85
+    # the last concordance window only includes two out of the three of the inserted bases: 18/20 = 0.9
     expected_concordance_list = [None]*10 + [0.85]*10 + [0.9] + [None]*9
 
     concordance_list = aligner.coord_concordance()

--- a/micall/tests/test_consensus_aligner.py
+++ b/micall/tests/test_consensus_aligner.py
@@ -834,7 +834,7 @@ def test_count_coord_concordance_short_match():
     aligner.coordinate_name = 'test-region'
     aligner.alignments = [AlignmentWrapper(r_st=0, r_en=15, q_st=0, q_en=15, cigar=[[15, CigarActions.MATCH]])]
     # as the averaging window (size 20) slides along the query, the concordance decreases from 15/20 = 0.75
-    # in 1 base intervals (1/20 = 0.05) down to 8 bases of the match left in the window (8/20 = 0.25)
+    # in 1 base intervals (1/20 = 0.05) down to 8 bases of the match left in the window (8/20 = 0.4)
     expected_concordance_list = [None]*10 + [0.75, 0.7, 0.65, 0.6, 0.55, 0.5, 0.45, 0.4] + [None]*9
 
     concordance_list = aligner.coord_concordance()

--- a/micall/tests/test_consensus_aligner.py
+++ b/micall/tests/test_consensus_aligner.py
@@ -833,9 +833,9 @@ def test_count_coord_concordance_short_match():
     aligner.consensus = "AGATTTCGATGATTCAGAAGATTTGCA"
     aligner.coordinate_name = 'test-region'
     aligner.alignments = [AlignmentWrapper(r_st=0, r_en=15, q_st=0, q_en=15, cigar=[[15, CigarActions.MATCH]])]
-    # as the averaging window (size 20) slides along the reference, the concordance decreases from 15/20 = 0.75
-    # in 1 base intervals (1/20 = 0.05) down to 5 bases of the match left in the window (5/20 = 0.25)
-    expected_concordance_list = [None]*10 + [0.75, 0.7, 0.65, 0.6, 0.55, 0.5, 0.45, 0.4, 0.35, 0.3, 0.25] + [None]*9
+    # as the averaging window (size 20) slides along the query, the concordance decreases from 15/20 = 0.75
+    # in 1 base intervals (1/20 = 0.05) down to 8 bases of the match left in the window (8/20 = 0.25)
+    expected_concordance_list = [None]*10 + [0.75, 0.7, 0.65, 0.6, 0.55, 0.5, 0.45, 0.4] + [None]*9
 
     concordance_list = aligner.coord_concordance()
 
@@ -874,8 +874,8 @@ def test_count_coord_concordance_with_insertion():
     aligner.alignments = [AlignmentWrapper(r_st=0, r_en=27, q_st=0, q_en=30, cigar=[[9, CigarActions.MATCH],
                                                                                     [3, CigarActions.INSERT],
                                                                                     [18, CigarActions.MATCH]])]
-
-    expected_concordance_list = [None]*10 + [1.0]*8 + [None]*9
+    # the insertion decreases the concordance. the last concordance window only includes two of the inserted bases
+    expected_concordance_list = [None]*10 + [0.85]*10 + [0.9] + [None]*9
 
     concordance_list = aligner.coord_concordance()
 
@@ -895,8 +895,8 @@ def test_count_coord_concordance_with_deletion():
     aligner.alignments = [AlignmentWrapper(r_st=0, r_en=27, q_st=0, q_en=30, cigar=[[9, CigarActions.MATCH],
                                                                                     [3, CigarActions.DELETE],
                                                                                     [15, CigarActions.MATCH]])]
-
-    expected_concordance_list = [None]*10 + [0.85]*8 + [None]*9
+    # the deletion does not decrease the concordance
+    expected_concordance_list = [None]*10 + [1.0]*5 + [None]*9
 
     concordance_list = aligner.coord_concordance()
 

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -927,7 +927,7 @@ class ConsensusAligner:
         except KeyError:
             coord_ref = self.projects.getReference(self.coordinate_name)
         query_matches = [0] * len(self.consensus)
-        concordance_list: typing.List[typing.Any] = [None] * len(coord_ref)
+        concordance_list: typing.List[typing.Any] = [None] * len(self.consensus)
 
         for alignment in coord_alignments:
             ref_progress = alignment.r_st

--- a/micall/utils/consensus_aligner.py
+++ b/micall/utils/consensus_aligner.py
@@ -926,7 +926,7 @@ class ConsensusAligner:
             coord_ref = self.projects.getGenotypeReference(self.coordinate_name)
         except KeyError:
             coord_ref = self.projects.getReference(self.coordinate_name)
-        query_matches = [0] * len(coord_ref)
+        query_matches = [0] * len(self.consensus)
         concordance_list: typing.List[typing.Any] = [None] * len(coord_ref)
 
         for alignment in coord_alignments:
@@ -943,11 +943,13 @@ class ConsensusAligner:
                         ref_pos = ref_progress + pos
                         query_pos = query_progress + pos
                         if self.consensus[query_pos] == coord_ref[ref_pos]:
-                            query_matches[ref_pos] = 1
+                            query_matches[query_pos] = 1
+                        else:
+                            query_matches[query_pos] = 0
                     ref_progress += size
                     query_progress += size
 
-        for pos in range(half_window_size, len(coord_ref) - half_window_size + 1):
+        for pos in range(half_window_size, len(self.consensus) - half_window_size + 1):
             concordance = sum(query_matches[pos - half_window_size:pos + half_window_size])
             normalized_concordance = concordance / (2 * half_window_size)
             concordance_list[pos] = normalized_concordance


### PR DESCRIPTION
The concordance lines were shifted with respect to the contigs, because they were aligned to the reference genome instead of the contigs. This PR fixes that issue, and also makes the documentation of genome_coverage.csv a little more obvious.

Closes #963