### PR TITLE
Read pipeline version from environment

### DIFF
--- a/micall_watcher.py
+++ b/micall_watcher.py
@@ -59,7 +59,7 @@ def parse_args(argv=None):
         help='folder to scan for raw data files, containing MiSeq/runs')
     parser.add_argument(
         '--pipeline_version',
-        default='0-dev',
+        default=os.environ.get('MICALL_PIPELINE_VERSION', '0-dev'),
         help='version suffix for batch names and folder names')
     parser.add_argument(
         '--kive_server',


### PR DESCRIPTION
If --pipeline_version is not specified from the CLI, try to read the environment variable named MICALL_PIPELINE_VERSION. This makes this option similar to all the other ones.

For compatibility, still default to "0-dev" if neither the environment nor command line arguments specify the version.