### PR TITLE
Adopt to proviral pipeline changes

### DIFF
--- a/micall/monitor/kive_watcher.py
+++ b/micall/monitor/kive_watcher.py
@@ -74,6 +74,7 @@ DOWNLOADED_RESULTS = ['remap_counts_csv',
                       'contigs_primers_csv',
                       'table_precursor_csv',
                       'proviral_landscape_csv',
+                      'hivseqinr_results_tar',  # TODO: remove when proviral is finally updated.
                       'detailed_results_tar']
 
 # noinspection PyArgumentList
@@ -781,7 +782,7 @@ class KiveWatcher:
             run = self.run_proviral_pipeline(
                 sample_watcher,
                 folder_watcher,
-                'Proviral HIVIntact')
+                'Proviral')
             return run
         if pipeline_type == PipelineType.RESISTANCE:
             run = self.run_resistance_pipeline(

--- a/micall/monitor/kive_watcher.py
+++ b/micall/monitor/kive_watcher.py
@@ -781,7 +781,7 @@ class KiveWatcher:
             run = self.run_proviral_pipeline(
                 sample_watcher,
                 folder_watcher,
-                'Proviral HIVSeqinR')
+                'Proviral HIVIntact')
             return run
         if pipeline_type == PipelineType.RESISTANCE:
             run = self.run_resistance_pipeline(

--- a/micall/monitor/kive_watcher.py
+++ b/micall/monitor/kive_watcher.py
@@ -74,7 +74,7 @@ DOWNLOADED_RESULTS = ['remap_counts_csv',
                       'contigs_primers_csv',
                       'table_precursor_csv',
                       'proviral_landscape_csv',
-                      'hivseqinr_results_tar']
+                      'detailed_results_tar']
 
 # noinspection PyArgumentList
 FolderEventType = Enum('FolderEventType', 'ADD_SAMPLE FINISH_FOLDER')

--- a/micall/tests/test_kive_watcher.py
+++ b/micall/tests/test_kive_watcher.py
@@ -3007,7 +3007,7 @@ def test_collate_denovo_results(raw_data_with_two_samples, default_config, mock_
 
     expected_cascade_path = version_folder / "denovo" / "cascade.csv"
     expected_done_path = version_folder / "denovo" / "doneprocessing"
-    proviral_path = version_folder / "denovo" / "hivseqinr_results"
+    proviral_path = version_folder / "denovo" / "detailed_results"
 
     main_scratch_path = version_folder / "scratch"
     main_scratch_path.mkdir()

--- a/micall/tests/test_kive_watcher.py
+++ b/micall/tests/test_kive_watcher.py
@@ -1784,7 +1784,7 @@ def test_launch_proviral_run(raw_data_with_two_samples, mock_open_kive):
                        dataset='/datasets/112/'),
                   dict(argument='/containerargs/106',
                        dataset='/datasets/113/')],
-        name='Proviral HIVIntact on 2120A',
+        name='Proviral on 2120A',
         batch='/batches/101',
         groups_allowed=['Everyone']))
 

--- a/micall/tests/test_kive_watcher.py
+++ b/micall/tests/test_kive_watcher.py
@@ -1784,7 +1784,7 @@ def test_launch_proviral_run(raw_data_with_two_samples, mock_open_kive):
                        dataset='/datasets/112/'),
                   dict(argument='/containerargs/106',
                        dataset='/datasets/113/')],
-        name='Proviral HIVSeqinR on 2120A',
+        name='Proviral HIVIntact on 2120A',
         batch='/batches/101',
         groups_allowed=['Everyone']))
 


### PR DESCRIPTION
As we are moving to HIVIntact in the proviral pipeline, several changes are affecting micall_watcher.
This patch makes it compatible with the changes.