### PR TITLE
Run apt-update on CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           go-version: '^1.15.6'
 
+      - name: Run apt update
+        run: sudo apt-get update
+
       - name: Install IVA assembler dependencies
         run: |
           sudo apt-get install -qq zlib1g-dev libncurses5-dev libncursesw5-dev mummer ncbi-blast+


### PR DESCRIPTION
Without this step, the following installation steps may fail spontaneously whenever the upstream servers update their IP addresses.