### PR TITLE
Update python to version 3.12

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.12
       - run: mkdir -p ~/bin
       - run: echo ~/bin >> $GITHUB_PATH
 
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - uses: actions/setup-go@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Check that Python is already installed.
 
     python --version
 
-We have tested with Python `3.11`.
+We have tested with Python `3.12`.
 
 ### BaseSpace
 Set up the [native apps virtual machine][bsvm], and configure a shared folder

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # If you omit the `--target` tag altogether, `docker build` will build
 # the development image.
 
-FROM python:3.11
+FROM python:3.12
 
 MAINTAINER BC CfE in HIV/AIDS https://github.com/cfe-lab/MiCall
 

--- a/Singularity
+++ b/Singularity
@@ -1,6 +1,6 @@
 # Generate the Singularity container to run MiCall on Kive.
 Bootstrap: docker
-From: python:3.11
+From: python:3.12
 
 %help
     MiCall maps all the reads from a sample against a set of reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ authors = [
 license = {text = "AGPL-3.0"}
 license-files = { paths = ["LICENSE.txt"] }
 readme = "README.md"
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.12,<3.13"
 classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
@@ -28,9 +28,9 @@ dependencies = [
     "biopython==1.83",
     "gotoh @ git+https://github.com/cfe-lab/gotoh.git@v0.3.0#egg=gotoh&subdirectory=alignment/gotoh",
     "pyvdrm @ git+https://github.com/cfe-lab/pyvdrm.git@v0.3.2",
-    "numpy==1.24.3",
-    "scipy==1.10.1",
-    "matplotlib==3.7.3",
+    "numpy==2.1.2",
+    "scipy==1.14.1",
+    "matplotlib==3.9.2",
     "cutadapt==4.8",
     "python-Levenshtein==0.25.1",
     "PyYAML==6.0.1",
@@ -48,7 +48,7 @@ test = [
     # Dependencies required for running the test suite
     "pytest==8.2.2",
     "coverage==7.5.3",
-    "pandas==2.0.2",
+    "pandas==2.2.3",
     "seaborn==0.13.2",
     "ete3",
     # For reading HCV rules from an Excel file.


### PR DESCRIPTION
This is the version used on current Ubuntu and Debian.

This requires updating critical dependencies, so:

- Bump numpy to 2.1.2
- Bump scipy to 1.14.1
- Bump matplotlib to 3.9.2