### PR TITLE
Make counting step in genotype() more reliable

### DIFF
--- a/micall/utils/fasta_to_csv.py
+++ b/micall/utils/fasta_to_csv.py
@@ -112,11 +112,10 @@ def genotype(contigs_fasta: Path, db: Optional[Path] = None,
     """
 
     contig_nums: Dict[str, int] = {}  # {contig_name: contig_num}
-    with open(contigs_fasta) as f:
-        for line in f:
-            if line.startswith('>'):
-                contig_name = line[1:-1]
-                contig_nums[contig_name] = len(contig_nums) + 1
+
+    for record in SeqIO.parse(contigs_fasta, "fasta"):
+        contig_name = record.name
+        contig_nums[contig_name] = len(contig_nums) + 1
 
     def invoke_blast(db: Path) -> str:
         return Blastn().genotype(


### PR DESCRIPTION
This change prevents crashes for weird contig names output by some assemblers.
This change ensures that BLAST and MiCall read the same contig names.

For the example of an issue, this is what Megahit outputs:

```fasta
>k21_0 flag=1 multi=15.5914 len=8949
GGACCTGAAAGCGAAAGGGAAACCA...GAAAGCGAAAGGGAAACC
```

Note how the contig name contains spaces.
These spaces caused divergence between MiCall and BLAST contig names.